### PR TITLE
fix: properly unescape special characters in JSON strings

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -513,7 +513,12 @@ impl<'text, 'a> RawJsonValue<'text, 'a> {
                 '\\' => {
                     let c = chars.next().expect("infallible");
                     match c {
-                        '\\' | '/' | '"' | 'n' | 't' | 'r' | 'b' | 'f' => unescaped.push(c),
+                        '\\' | '/' | '"' => unescaped.push(c),
+                        'n' => unescaped.push('\n'),
+                        't' => unescaped.push('\t'),
+                        'r' => unescaped.push('\r'),
+                        'b' => unescaped.push('\u{8}'),
+                        'f' => unescaped.push('\u{c}'),
                         'u' => {
                             let c = std::str::from_utf8(&[
                                 chars.next().expect("infallible") as u8,

--- a/tests/test_parse.rs
+++ b/tests/test_parse.rs
@@ -192,10 +192,10 @@ fn parse_strings() -> Result<(), JsonParseError> {
     }
 
     // Escaped strings.
-    for text in [
-        r#" "ab\tc" "#,
-        r#" "\n\\a\r\nb\b\"\fc" "#,
-        r#" "ab\uF20ac" "#,
+    for (text, unescaped) in [
+        (r#" "ab\tc" "#, "ab\tc"),
+        (r#" "\n\\a\r\nb\b\"\fc" "#, "\n\\a\r\nb\u{8}\"\u{c}c"),
+        (r#" "ab\uF20ac" "#, "ab\u{f20a}c"),
     ] {
         let json = RawJson::parse(text)?;
         let value = json.value();
@@ -203,6 +203,7 @@ fn parse_strings() -> Result<(), JsonParseError> {
         assert_eq!(value.as_raw_str(), text.trim());
         assert_eq!(value.position(), 1);
         assert!(matches!(value.to_unquoted_string_str(), Ok(Cow::Owned(_))));
+        assert_eq!(value.to_unquoted_string_str().expect("ok"), unescaped);
     }
 
     // Malformed strings.


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes changes to improve the handling and testing of escaped characters in JSON strings. The most important changes include refining the unescaping logic in the `RawJsonValue` implementation and updating the corresponding tests to verify the correct unescaping behavior.

Improvements to unescaping logic:

* [`src/raw.rs`](diffhunk://#diff-1607fceedc86cbe67fcadde7bbb1eb930e7324ffbaf831736f1246c77197a506L516-R521): Modified the `RawJsonValue` implementation to handle specific escaped characters (`\n`, `\t`, `\r`, `\b`, `\f`) by converting them to their respective character representations.

Updates to tests:

* [`tests/test_parse.rs`](diffhunk://#diff-67211e9eb4ff5e321abb6619e4e604eefe81cb71a667e5cd49c63c3b5fdc77c0L195-R206): Updated the `parse_strings` function to include pairs of escaped and unescaped strings, ensuring the unescaping logic is correctly verified. Added assertions to check the unescaped string values.