### PR TITLE
Add `DisplayJson` and `FromRawJsonValue` implementations for std types

### DIFF
--- a/src/display_json.rs
+++ b/src/display_json.rs
@@ -97,7 +97,13 @@ pub trait DisplayJson {
 
 impl<T: DisplayJson + ?Sized> DisplayJson for &T {
     fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
-        (*self).fmt(f)
+        (**self).fmt(f)
+    }
+}
+
+impl<T: DisplayJson + ?Sized> DisplayJson for &mut T {
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        (**self).fmt(f)
     }
 }
 

--- a/src/display_json.rs
+++ b/src/display_json.rs
@@ -297,6 +297,18 @@ impl DisplayJson for String {
     }
 }
 
+impl DisplayJson for &std::path::Path {
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.string(self.display())
+    }
+}
+
+impl DisplayJson for std::path::PathBuf {
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.string(self.display())
+    }
+}
+
 impl<T: DisplayJson, const N: usize> DisplayJson for [T; N] {
     fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
         f.array(|f| f.elements(self.iter()))

--- a/src/display_json.rs
+++ b/src/display_json.rs
@@ -309,6 +309,42 @@ impl DisplayJson for std::path::PathBuf {
     }
 }
 
+impl DisplayJson for std::net::SocketAddr {
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.string(self)
+    }
+}
+
+impl DisplayJson for std::net::SocketAddrV4 {
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.string(self)
+    }
+}
+
+impl DisplayJson for std::net::SocketAddrV6 {
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.string(self)
+    }
+}
+
+impl DisplayJson for std::net::IpAddr {
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.string(self)
+    }
+}
+
+impl DisplayJson for std::net::Ipv4Addr {
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.string(self)
+    }
+}
+
+impl DisplayJson for std::net::Ipv6Addr {
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.string(self)
+    }
+}
+
 impl<T: DisplayJson, const N: usize> DisplayJson for [T; N] {
     fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
         f.array(|f| f.elements(self.iter()))

--- a/src/from_raw_json_value.rs
+++ b/src/from_raw_json_value.rs
@@ -332,6 +332,67 @@ impl<'text> FromRawJsonValue<'text> for std::borrow::Cow<'text, str> {
     }
 }
 
+impl<'text> FromRawJsonValue<'text> for std::path::PathBuf {
+    fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
+        let path = value.to_unquoted_string_str()?.into_owned();
+        Ok(std::path::PathBuf::from(path))
+    }
+}
+
+impl<'text> FromRawJsonValue<'text> for std::net::IpAddr {
+    fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
+        value
+            .to_unquoted_string_str()?
+            .parse()
+            .map_err(|e| JsonParseError::invalid_value(value, e))
+    }
+}
+
+impl<'text> FromRawJsonValue<'text> for std::net::Ipv4Addr {
+    fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
+        value
+            .to_unquoted_string_str()?
+            .parse()
+            .map_err(|e| JsonParseError::invalid_value(value, e))
+    }
+}
+
+impl<'text> FromRawJsonValue<'text> for std::net::Ipv6Addr {
+    fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
+        value
+            .to_unquoted_string_str()?
+            .parse()
+            .map_err(|e| JsonParseError::invalid_value(value, e))
+    }
+}
+
+impl<'text> FromRawJsonValue<'text> for std::net::SocketAddr {
+    fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
+        value
+            .to_unquoted_string_str()?
+            .parse()
+            .map_err(|e| JsonParseError::invalid_value(value, e))
+    }
+}
+
+impl<'text> FromRawJsonValue<'text> for std::net::SocketAddrV4 {
+    fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
+        value
+            .to_unquoted_string_str()?
+            .parse()
+            .map_err(|e| JsonParseError::invalid_value(value, e))
+    }
+}
+
+impl<'text> FromRawJsonValue<'text> for std::net::SocketAddrV6 {
+    fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
+        value
+            .to_unquoted_string_str()?
+            .parse()
+            .map_err(|e| JsonParseError::invalid_value(value, e))
+    }
+}
+
 impl<'text, T: FromRawJsonValue<'text>> FromRawJsonValue<'text> for Vec<T> {
     fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
         value.to_array()?.map(T::from_raw_json_value).collect()
@@ -398,12 +459,8 @@ impl<'text, T0: FromRawJsonValue<'text>, T1: FromRawJsonValue<'text>> FromRawJso
     }
 }
 
-impl<
-        'text,
-        T0: FromRawJsonValue<'text>,
-        T1: FromRawJsonValue<'text>,
-        T2: FromRawJsonValue<'text>,
-    > FromRawJsonValue<'text> for (T0, T1, T2)
+impl<'text, T0: FromRawJsonValue<'text>, T1: FromRawJsonValue<'text>, T2: FromRawJsonValue<'text>>
+    FromRawJsonValue<'text> for (T0, T1, T2)
 {
     fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
         let [v0, v1, v2] = value.to_fixed_array()?;
@@ -412,12 +469,12 @@ impl<
 }
 
 impl<
-        'text,
-        T0: FromRawJsonValue<'text>,
-        T1: FromRawJsonValue<'text>,
-        T2: FromRawJsonValue<'text>,
-        T3: FromRawJsonValue<'text>,
-    > FromRawJsonValue<'text> for (T0, T1, T2, T3)
+    'text,
+    T0: FromRawJsonValue<'text>,
+    T1: FromRawJsonValue<'text>,
+    T2: FromRawJsonValue<'text>,
+    T3: FromRawJsonValue<'text>,
+> FromRawJsonValue<'text> for (T0, T1, T2, T3)
 {
     fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
         let [v0, v1, v2, v3] = value.to_fixed_array()?;
@@ -426,13 +483,13 @@ impl<
 }
 
 impl<
-        'text,
-        T0: FromRawJsonValue<'text>,
-        T1: FromRawJsonValue<'text>,
-        T2: FromRawJsonValue<'text>,
-        T3: FromRawJsonValue<'text>,
-        T4: FromRawJsonValue<'text>,
-    > FromRawJsonValue<'text> for (T0, T1, T2, T3, T4)
+    'text,
+    T0: FromRawJsonValue<'text>,
+    T1: FromRawJsonValue<'text>,
+    T2: FromRawJsonValue<'text>,
+    T3: FromRawJsonValue<'text>,
+    T4: FromRawJsonValue<'text>,
+> FromRawJsonValue<'text> for (T0, T1, T2, T3, T4)
 {
     fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
         let [v0, v1, v2, v3, v4] = value.to_fixed_array()?;
@@ -447,14 +504,14 @@ impl<
 }
 
 impl<
-        'text,
-        T0: FromRawJsonValue<'text>,
-        T1: FromRawJsonValue<'text>,
-        T2: FromRawJsonValue<'text>,
-        T3: FromRawJsonValue<'text>,
-        T4: FromRawJsonValue<'text>,
-        T5: FromRawJsonValue<'text>,
-    > FromRawJsonValue<'text> for (T0, T1, T2, T3, T4, T5)
+    'text,
+    T0: FromRawJsonValue<'text>,
+    T1: FromRawJsonValue<'text>,
+    T2: FromRawJsonValue<'text>,
+    T3: FromRawJsonValue<'text>,
+    T4: FromRawJsonValue<'text>,
+    T5: FromRawJsonValue<'text>,
+> FromRawJsonValue<'text> for (T0, T1, T2, T3, T4, T5)
 {
     fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
         let [v0, v1, v2, v3, v4, v5] = value.to_fixed_array()?;
@@ -470,15 +527,15 @@ impl<
 }
 
 impl<
-        'text,
-        T0: FromRawJsonValue<'text>,
-        T1: FromRawJsonValue<'text>,
-        T2: FromRawJsonValue<'text>,
-        T3: FromRawJsonValue<'text>,
-        T4: FromRawJsonValue<'text>,
-        T5: FromRawJsonValue<'text>,
-        T6: FromRawJsonValue<'text>,
-    > FromRawJsonValue<'text> for (T0, T1, T2, T3, T4, T5, T6)
+    'text,
+    T0: FromRawJsonValue<'text>,
+    T1: FromRawJsonValue<'text>,
+    T2: FromRawJsonValue<'text>,
+    T3: FromRawJsonValue<'text>,
+    T4: FromRawJsonValue<'text>,
+    T5: FromRawJsonValue<'text>,
+    T6: FromRawJsonValue<'text>,
+> FromRawJsonValue<'text> for (T0, T1, T2, T3, T4, T5, T6)
 {
     fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
         let [v0, v1, v2, v3, v4, v5, v6] = value.to_fixed_array()?;
@@ -495,16 +552,16 @@ impl<
 }
 
 impl<
-        'text,
-        T0: FromRawJsonValue<'text>,
-        T1: FromRawJsonValue<'text>,
-        T2: FromRawJsonValue<'text>,
-        T3: FromRawJsonValue<'text>,
-        T4: FromRawJsonValue<'text>,
-        T5: FromRawJsonValue<'text>,
-        T6: FromRawJsonValue<'text>,
-        T7: FromRawJsonValue<'text>,
-    > FromRawJsonValue<'text> for (T0, T1, T2, T3, T4, T5, T6, T7)
+    'text,
+    T0: FromRawJsonValue<'text>,
+    T1: FromRawJsonValue<'text>,
+    T2: FromRawJsonValue<'text>,
+    T3: FromRawJsonValue<'text>,
+    T4: FromRawJsonValue<'text>,
+    T5: FromRawJsonValue<'text>,
+    T6: FromRawJsonValue<'text>,
+    T7: FromRawJsonValue<'text>,
+> FromRawJsonValue<'text> for (T0, T1, T2, T3, T4, T5, T6, T7)
 {
     fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
         let [v0, v1, v2, v3, v4, v5, v6, v7] = value.to_fixed_array()?;
@@ -560,12 +617,5 @@ where
                 ))
             })
             .collect()
-    }
-}
-
-impl<'text> FromRawJsonValue<'text> for std::path::PathBuf {
-    fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
-        let path = value.to_unquoted_string_str()?.into_owned();
-        Ok(std::path::PathBuf::from(path))
     }
 }

--- a/src/from_raw_json_value.rs
+++ b/src/from_raw_json_value.rs
@@ -398,8 +398,12 @@ impl<'text, T0: FromRawJsonValue<'text>, T1: FromRawJsonValue<'text>> FromRawJso
     }
 }
 
-impl<'text, T0: FromRawJsonValue<'text>, T1: FromRawJsonValue<'text>, T2: FromRawJsonValue<'text>>
-    FromRawJsonValue<'text> for (T0, T1, T2)
+impl<
+        'text,
+        T0: FromRawJsonValue<'text>,
+        T1: FromRawJsonValue<'text>,
+        T2: FromRawJsonValue<'text>,
+    > FromRawJsonValue<'text> for (T0, T1, T2)
 {
     fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
         let [v0, v1, v2] = value.to_fixed_array()?;
@@ -408,12 +412,12 @@ impl<'text, T0: FromRawJsonValue<'text>, T1: FromRawJsonValue<'text>, T2: FromRa
 }
 
 impl<
-    'text,
-    T0: FromRawJsonValue<'text>,
-    T1: FromRawJsonValue<'text>,
-    T2: FromRawJsonValue<'text>,
-    T3: FromRawJsonValue<'text>,
-> FromRawJsonValue<'text> for (T0, T1, T2, T3)
+        'text,
+        T0: FromRawJsonValue<'text>,
+        T1: FromRawJsonValue<'text>,
+        T2: FromRawJsonValue<'text>,
+        T3: FromRawJsonValue<'text>,
+    > FromRawJsonValue<'text> for (T0, T1, T2, T3)
 {
     fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
         let [v0, v1, v2, v3] = value.to_fixed_array()?;
@@ -422,13 +426,13 @@ impl<
 }
 
 impl<
-    'text,
-    T0: FromRawJsonValue<'text>,
-    T1: FromRawJsonValue<'text>,
-    T2: FromRawJsonValue<'text>,
-    T3: FromRawJsonValue<'text>,
-    T4: FromRawJsonValue<'text>,
-> FromRawJsonValue<'text> for (T0, T1, T2, T3, T4)
+        'text,
+        T0: FromRawJsonValue<'text>,
+        T1: FromRawJsonValue<'text>,
+        T2: FromRawJsonValue<'text>,
+        T3: FromRawJsonValue<'text>,
+        T4: FromRawJsonValue<'text>,
+    > FromRawJsonValue<'text> for (T0, T1, T2, T3, T4)
 {
     fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
         let [v0, v1, v2, v3, v4] = value.to_fixed_array()?;
@@ -443,14 +447,14 @@ impl<
 }
 
 impl<
-    'text,
-    T0: FromRawJsonValue<'text>,
-    T1: FromRawJsonValue<'text>,
-    T2: FromRawJsonValue<'text>,
-    T3: FromRawJsonValue<'text>,
-    T4: FromRawJsonValue<'text>,
-    T5: FromRawJsonValue<'text>,
-> FromRawJsonValue<'text> for (T0, T1, T2, T3, T4, T5)
+        'text,
+        T0: FromRawJsonValue<'text>,
+        T1: FromRawJsonValue<'text>,
+        T2: FromRawJsonValue<'text>,
+        T3: FromRawJsonValue<'text>,
+        T4: FromRawJsonValue<'text>,
+        T5: FromRawJsonValue<'text>,
+    > FromRawJsonValue<'text> for (T0, T1, T2, T3, T4, T5)
 {
     fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
         let [v0, v1, v2, v3, v4, v5] = value.to_fixed_array()?;
@@ -466,15 +470,15 @@ impl<
 }
 
 impl<
-    'text,
-    T0: FromRawJsonValue<'text>,
-    T1: FromRawJsonValue<'text>,
-    T2: FromRawJsonValue<'text>,
-    T3: FromRawJsonValue<'text>,
-    T4: FromRawJsonValue<'text>,
-    T5: FromRawJsonValue<'text>,
-    T6: FromRawJsonValue<'text>,
-> FromRawJsonValue<'text> for (T0, T1, T2, T3, T4, T5, T6)
+        'text,
+        T0: FromRawJsonValue<'text>,
+        T1: FromRawJsonValue<'text>,
+        T2: FromRawJsonValue<'text>,
+        T3: FromRawJsonValue<'text>,
+        T4: FromRawJsonValue<'text>,
+        T5: FromRawJsonValue<'text>,
+        T6: FromRawJsonValue<'text>,
+    > FromRawJsonValue<'text> for (T0, T1, T2, T3, T4, T5, T6)
 {
     fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
         let [v0, v1, v2, v3, v4, v5, v6] = value.to_fixed_array()?;
@@ -491,16 +495,16 @@ impl<
 }
 
 impl<
-    'text,
-    T0: FromRawJsonValue<'text>,
-    T1: FromRawJsonValue<'text>,
-    T2: FromRawJsonValue<'text>,
-    T3: FromRawJsonValue<'text>,
-    T4: FromRawJsonValue<'text>,
-    T5: FromRawJsonValue<'text>,
-    T6: FromRawJsonValue<'text>,
-    T7: FromRawJsonValue<'text>,
-> FromRawJsonValue<'text> for (T0, T1, T2, T3, T4, T5, T6, T7)
+        'text,
+        T0: FromRawJsonValue<'text>,
+        T1: FromRawJsonValue<'text>,
+        T2: FromRawJsonValue<'text>,
+        T3: FromRawJsonValue<'text>,
+        T4: FromRawJsonValue<'text>,
+        T5: FromRawJsonValue<'text>,
+        T6: FromRawJsonValue<'text>,
+        T7: FromRawJsonValue<'text>,
+    > FromRawJsonValue<'text> for (T0, T1, T2, T3, T4, T5, T6, T7)
 {
     fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
         let [v0, v1, v2, v3, v4, v5, v6, v7] = value.to_fixed_array()?;
@@ -556,5 +560,12 @@ where
                 ))
             })
             .collect()
+    }
+}
+
+impl<'text> FromRawJsonValue<'text> for std::path::PathBuf {
+    fn from_raw_json_value(value: RawJsonValue<'text, '_>) -> Result<Self, JsonParseError> {
+        let path = value.to_unquoted_string_str()?.into_owned();
+        Ok(std::path::PathBuf::from(path))
     }
 }


### PR DESCRIPTION
# Copilot Summary 

This pull request introduces several enhancements to the `DisplayJson` and `FromRawJsonValue` traits, primarily adding implementations for various standard library types. These changes aim to improve the flexibility and usability of these traits when working with JSON data.

Enhancements to `DisplayJson` trait:

* Added implementations for `&std::path::Path` and `std::path::PathBuf` to format these types as JSON strings.
* Added implementations for `std::net::SocketAddr`, `std::net::SocketAddrV4`, `std::net::SocketAddrV6`, `std::net::IpAddr`, `std::net::Ipv4Addr`, and `std::net::Ipv6Addr` to format these types as JSON strings.

Enhancements to `FromRawJsonValue` trait:

* Added implementations for `std::path::PathBuf` to convert raw JSON values into `PathBuf` instances.
* Added implementations for `std::net::IpAddr`, `std::net::Ipv4Addr`, `std::net::Ipv6Addr`, `std::net::SocketAddr`, `std::net::SocketAddrV4`, and `std::net::SocketAddrV6` to convert raw JSON values into respective network address types.

Codebase improvements:

* Modified the `DisplayJson` trait implementations for references to use double dereferencing for consistency.
