### PR TITLE
Fix infinity recursion when displaying floats

### DIFF
--- a/src/display_json.rs
+++ b/src/display_json.rs
@@ -275,13 +275,21 @@ impl DisplayJson for std::num::NonZeroUsize {
 
 impl DisplayJson for f32 {
     fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
-        self.is_finite().then_some(self).fmt(f)
+        if self.is_finite() {
+            write!(f.inner_mut(), "{}", self)
+        } else {
+            write!(f.inner_mut(), "null")
+        }
     }
 }
 
 impl DisplayJson for f64 {
     fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
-        self.is_finite().then_some(self).fmt(f)
+        if self.is_finite() {
+            write!(f.inner_mut(), "{}", self)
+        } else {
+            write!(f.inner_mut(), "null")
+        }
     }
 }
 

--- a/tests/test_format.rs
+++ b/tests/test_format.rs
@@ -3,6 +3,12 @@ use std::collections::BTreeMap;
 use nojson::{DisplayJson, Json, json};
 
 #[test]
+fn float() {
+    assert_eq!(json(|f| f.value(1.23f32)).to_string(), "1.23");
+    assert_eq!(json(|f| f.value(1.23f64)).to_string(), "1.23");
+}
+
+#[test]
 fn array() {
     assert_eq!(Json([1, 2, 3]).to_string(), "[1,2,3]");
     assert_eq!(Json([Some(1), None, Some(3)]).to_string(), "[1,null,3]");

--- a/tests/test_format.rs
+++ b/tests/test_format.rs
@@ -6,6 +6,11 @@ use nojson::{DisplayJson, Json, json};
 fn float() {
     assert_eq!(json(|f| f.value(1.23f32)).to_string(), "1.23");
     assert_eq!(json(|f| f.value(1.23f64)).to_string(), "1.23");
+
+    assert_eq!(json(|f| f.value(f32::NAN)).to_string(), "null");
+    assert_eq!(json(|f| f.value(f64::NAN)).to_string(), "null");
+    assert_eq!(json(|f| f.value(f32::INFINITY)).to_string(), "null");
+    assert_eq!(json(|f| f.value(f64::INFINITY)).to_string(), "null");
 }
 
 #[test]


### PR DESCRIPTION
# Copilot Summary 

This pull request includes changes to improve the handling of floating-point numbers in JSON formatting and adds new tests for these improvements. The most important changes are:

Improvements to JSON formatting:

* [`src/display_json.rs`](diffhunk://#diff-306616aca861614390fc20c0ea561ac604a276713b01cbb2cc8dbf6ceaa135b3L278-R292): Modified the `DisplayJson` implementation for `f32` and `f64` to handle non-finite values by writing `"null"` instead of using `then_some`.

Addition of new tests:

* [`tests/test_format.rs`](diffhunk://#diff-1cea2c77eedc0a62ced8a39a4536400f3b21ce5a11e6738a357f95f030d82945R5-R10): Added a new test function `float` to verify the correct JSON formatting of finite `f32` and `f64` values.