### PR TITLE
Implement DisplayJson for tuples of various sizes

### DIFF
--- a/src/display_json.rs
+++ b/src/display_json.rs
@@ -389,6 +389,133 @@ impl<T: DisplayJson> DisplayJson for std::collections::HashSet<T> {
     }
 }
 
+impl DisplayJson for () {
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.array(|_| Ok(()))
+    }
+}
+
+impl<T0: DisplayJson> DisplayJson for (T0,) {
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.array(|f| f.element(&self.0))
+    }
+}
+
+impl<T0: DisplayJson, T1: DisplayJson> DisplayJson for (T0, T1) {
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.array(|f| {
+            f.element(&self.0)?;
+            f.element(&self.1)
+        })
+    }
+}
+
+impl<T0: DisplayJson, T1: DisplayJson, T2: DisplayJson> DisplayJson for (T0, T1, T2) {
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.array(|f| {
+            f.element(&self.0)?;
+            f.element(&self.1)?;
+            f.element(&self.2)
+        })
+    }
+}
+
+impl<T0: DisplayJson, T1: DisplayJson, T2: DisplayJson, T3: DisplayJson> DisplayJson
+    for (T0, T1, T2, T3)
+{
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.array(|f| {
+            f.element(&self.0)?;
+            f.element(&self.1)?;
+            f.element(&self.2)?;
+            f.element(&self.3)
+        })
+    }
+}
+
+impl<T0: DisplayJson, T1: DisplayJson, T2: DisplayJson, T3: DisplayJson, T4: DisplayJson>
+    DisplayJson for (T0, T1, T2, T3, T4)
+{
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.array(|f| {
+            f.element(&self.0)?;
+            f.element(&self.1)?;
+            f.element(&self.2)?;
+            f.element(&self.3)?;
+            f.element(&self.4)
+        })
+    }
+}
+
+impl<
+    T0: DisplayJson,
+    T1: DisplayJson,
+    T2: DisplayJson,
+    T3: DisplayJson,
+    T4: DisplayJson,
+    T5: DisplayJson,
+> DisplayJson for (T0, T1, T2, T3, T4, T5)
+{
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.array(|f| {
+            f.element(&self.0)?;
+            f.element(&self.1)?;
+            f.element(&self.2)?;
+            f.element(&self.3)?;
+            f.element(&self.4)?;
+            f.element(&self.5)
+        })
+    }
+}
+
+impl<
+    T0: DisplayJson,
+    T1: DisplayJson,
+    T2: DisplayJson,
+    T3: DisplayJson,
+    T4: DisplayJson,
+    T5: DisplayJson,
+    T6: DisplayJson,
+> DisplayJson for (T0, T1, T2, T3, T4, T5, T6)
+{
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.array(|f| {
+            f.element(&self.0)?;
+            f.element(&self.1)?;
+            f.element(&self.2)?;
+            f.element(&self.3)?;
+            f.element(&self.4)?;
+            f.element(&self.5)?;
+            f.element(&self.6)
+        })
+    }
+}
+
+impl<
+    T0: DisplayJson,
+    T1: DisplayJson,
+    T2: DisplayJson,
+    T3: DisplayJson,
+    T4: DisplayJson,
+    T5: DisplayJson,
+    T6: DisplayJson,
+    T7: DisplayJson,
+> DisplayJson for (T0, T1, T2, T3, T4, T5, T6, T7)
+{
+    fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.array(|f| {
+            f.element(&self.0)?;
+            f.element(&self.1)?;
+            f.element(&self.2)?;
+            f.element(&self.3)?;
+            f.element(&self.4)?;
+            f.element(&self.5)?;
+            f.element(&self.6)?;
+            f.element(&self.7)
+        })
+    }
+}
+
 impl<K: Display, V: DisplayJson> DisplayJson for std::collections::BTreeMap<K, V> {
     fn fmt(&self, f: &mut JsonFormatter<'_, '_>) -> std::fmt::Result {
         f.object(|f| f.members(self.iter()))


### PR DESCRIPTION
# Copilot Summary 

This pull request introduces several new implementations of the `DisplayJson` trait for tuples of varying lengths in the `src/display_json.rs` file. These changes enhance the flexibility of the `DisplayJson` trait by allowing it to handle tuples with up to eight elements.

New implementations of `DisplayJson` trait:

* Added `DisplayJson` implementations for tuples with one to eight elements, allowing each tuple element to be formatted as a JSON array.