### PR TITLE
Add `RawJsonOwned` struct and value extraction functionality

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ use std::{fmt::Display, str::FromStr};
 pub use display_json::DisplayJson;
 pub use format::{JsonArrayFormatter, JsonFormatter, JsonObjectFormatter};
 pub use kind::JsonValueKind;
-pub use raw::{JsonParseError, RawJson, RawJsonMember, RawJsonValue};
+pub use raw::{JsonParseError, RawJson, RawJsonMember, RawJsonOwned, RawJsonValue};
 
 /// A marker struct that enables JSON parsing and generation through the [`FromStr`] and [`Display`] traits.
 ///

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -468,7 +468,7 @@ impl<'text, 'raw> RawJsonValue<'text, 'raw> {
     /// let user_value = json.value().to_member("user")?.required()?;
     ///
     /// // Extract the user object and its children to borrowed
-    /// let borrowed_user = user_value.extract_to_raw_json();
+    /// let borrowed_user = user_value.extract();
     ///
     /// // The borrowed version references the original text
     /// assert_eq!(borrowed_user.text(), r#"{"name": "John", "age": 30}"#);
@@ -480,7 +480,7 @@ impl<'text, 'raw> RawJsonValue<'text, 'raw> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn extract_to_raw_json(self) -> RawJson<'text> {
+    pub fn extract(self) -> RawJson<'text> {
         let start_index = self.index;
         let end_index = self.entry().end_index;
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -449,12 +449,12 @@ impl<'text, 'raw> RawJsonValue<'text, 'raw> {
         &self.json.text[text.start..text.end]
     }
 
-    /// Converts this value into an owned [`RawJsonOwned`] containing just this value and its children.
+    /// Converts this value to an owned [`RawJsonOwned`] containing just this value and its children.
     ///
     /// This method creates an owned copy of this specific JSON value and its text,
     /// including all nested children if the value is an object or array. The resulting
     /// [`RawJsonOwned`] contains only this value and its descendants as its root,
-    /// not the entire original JSON document.
+    /// not the entire original JSON text.
     ///
     /// # Example
     ///
@@ -465,8 +465,8 @@ impl<'text, 'raw> RawJsonValue<'text, 'raw> {
     /// let json = RawJson::parse(text)?;
     /// let user_value = json.value().to_member("user")?.required()?;
     ///
-    /// // Convert the user object and its children to owned
-    /// let owned_user = user_value.into_raw_json_owned();
+    /// // Extract the user object and its children to owned
+    /// let owned_user = user_value.extract_to_raw_json_owned();
     ///
     /// // The owned version can outlive the original text and includes all nested data
     /// drop(text);
@@ -476,34 +476,26 @@ impl<'text, 'raw> RawJsonValue<'text, 'raw> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn into_raw_json_owned(self) -> RawJsonOwned {
+    pub fn extract_to_raw_json_owned(self) -> RawJsonOwned {
         let start_index = self.index;
         let end_index = self.entry().end_index;
 
         // Extract the text range that covers this value and all its children
         let start_pos = self.entry().text.start;
-        let end_pos = self.entry().text.end; // Use this value's own end position, which includes closing braces/brackets
-
+        let end_pos = self.entry().text.end;
         let value_text = &self.json.text[start_pos..end_pos];
 
         // Extract all relevant value entries (this value and its children)
         let relevant_entries = &self.json.values[start_index..end_index];
 
         // Create new values vector with adjusted positions
-        let new_values: Vec<JsonValueIndexEntry> = relevant_entries
+        let new_values = relevant_entries
             .iter()
-            .enumerate()
-            .map(|(i, entry)| JsonValueIndexEntry {
+            .map(|entry| JsonValueIndexEntry {
                 kind: entry.kind,
                 escaped: entry.escaped,
                 text: (entry.text.start - start_pos)..(entry.text.end - start_pos),
-                end_index: if i == 0 {
-                    // Root entry should have end_index equal to total number of entries
-                    relevant_entries.len()
-                } else {
-                    // Adjust relative to the new indexing
-                    entry.end_index - start_index
-                },
+                end_index: entry.end_index - start_index,
             })
             .collect();
 


### PR DESCRIPTION
- **Refactor RawJson to use internal RawJsonRef for better encapsulation and code reuse**
- **Add RawJsonOwned struct with owned JSON data and conversion methods**
- **Add into_raw_json_owned() method to convert RawJsonValue to owned copy**
- **Update documentation and simplify `extract_to_raw_json_owned` method implementation**
- **feat: change extract_to_raw_json_owned to return borrowed RawJson instead of owned**
- **Rename `extract_to_raw_json` method to `extract` for brevity**
