### PR TITLE
Optimize JSON string processing with SWAR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,36 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +66,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +88,103 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "errno"
@@ -102,6 +235,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,8 +293,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
 name = "nojson"
 version = "0.3.9"
+dependencies = [
+ "criterion",
+]
 
 [[package]]
 name = "num-traits"
@@ -151,6 +319,22 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "pbt"
@@ -257,6 +441,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +492,58 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -318,6 +577,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +608,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +625,37 @@ checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -387,3 +697,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,16 @@ categories = ["encoding", "no-std", "parser-implementations"]
 default = ["std"]
 std = []
 
+[dev-dependencies]
+criterion = { version = "0.8", default-features = false }
+
+[[bench]]
+name = "parse"
+harness = false
+
+[[bench]]
+name = "format"
+harness = false
+
 [workspace]
 members = ["fuzz", "pbt"]

--- a/benches/format.rs
+++ b/benches/format.rs
@@ -10,6 +10,11 @@ fn gen_mixed_escapes(len: usize) -> String {
     base.chars().cycle().take(len).collect()
 }
 
+fn gen_unicode_heavy(len: usize) -> String {
+    let chars = "あいうえおかきくけこ日本語テスト🎉🚀✨";
+    chars.chars().cycle().take(len).collect()
+}
+
 fn bench_format(c: &mut Criterion) {
     let mut group = c.benchmark_group("format");
 
@@ -29,6 +34,16 @@ fn bench_format(c: &mut Criterion) {
     let input = gen_mixed_escapes(256);
     group.bench_with_input(
         BenchmarkId::new("mixed_escapes", "256B"),
+        &input,
+        |b, input| {
+            b.iter(|| nojson::json(|f| f.value(input.as_str())).to_string());
+        },
+    );
+
+    // Unicode heavy
+    let input = gen_unicode_heavy(200);
+    group.bench_with_input(
+        BenchmarkId::new("unicode_heavy", "200ch"),
         &input,
         |b, input| {
             b.iter(|| nojson::json(|f| f.value(input.as_str())).to_string());

--- a/benches/format.rs
+++ b/benches/format.rs
@@ -45,7 +45,11 @@ fn bench_format(c: &mut Criterion) {
             )
         })
         .collect();
-    let pairs: Vec<(&str, &str)> = keys.iter().zip(values.iter()).map(|(k, v)| (k.as_str(), v.as_str())).collect();
+    let pairs: Vec<(&str, &str)> = keys
+        .iter()
+        .zip(values.iter())
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
     group.bench_with_input(
         BenchmarkId::new("object_formatting", "50pairs"),
         &pairs,

--- a/benches/format.rs
+++ b/benches/format.rs
@@ -1,0 +1,71 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+fn gen_plain_ascii(len: usize) -> String {
+    let base = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ,.:;!?-_";
+    base.chars().cycle().take(len).collect()
+}
+
+fn gen_mixed_escapes(len: usize) -> String {
+    let base = "hello world\nthis has \"quotes\" and \\backslashes\r\nand\ttabs";
+    base.chars().cycle().take(len).collect()
+}
+
+fn bench_format(c: &mut Criterion) {
+    let mut group = c.benchmark_group("format");
+
+    // Plain ASCII string formatting
+    for &len in &[64, 256, 1024] {
+        let input = gen_plain_ascii(len);
+        group.bench_with_input(
+            BenchmarkId::new("plain_ascii", format!("{}B", len)),
+            &input,
+            |b, input| {
+                b.iter(|| nojson::json(|f| f.value(input.as_str())).to_string());
+            },
+        );
+    }
+
+    // Mixed escapes
+    let input = gen_mixed_escapes(256);
+    group.bench_with_input(
+        BenchmarkId::new("mixed_escapes", "256B"),
+        &input,
+        |b, input| {
+            b.iter(|| nojson::json(|f| f.value(input.as_str())).to_string());
+        },
+    );
+
+    // Object with many string key-value pairs
+    let keys: Vec<String> = (0..50).map(|i| format!("key_{}", i)).collect();
+    let values: Vec<String> = (0..50)
+        .map(|i| {
+            format!(
+                "This is value number {} with a reasonably long text content for benchmarking",
+                i
+            )
+        })
+        .collect();
+    let pairs: Vec<(&str, &str)> = keys.iter().zip(values.iter()).map(|(k, v)| (k.as_str(), v.as_str())).collect();
+    group.bench_with_input(
+        BenchmarkId::new("object_formatting", "50pairs"),
+        &pairs,
+        |b, pairs| {
+            b.iter(|| {
+                nojson::json(|f| {
+                    f.object(|f| {
+                        for &(k, v) in pairs.iter() {
+                            f.member(k, v)?;
+                        }
+                        Ok(())
+                    })
+                })
+                .to_string()
+            });
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_format);
+criterion_main!(benches);

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,0 +1,121 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+fn gen_long_ascii(len: usize) -> String {
+    let base = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ,.:;!?-_";
+    let body: String = base.chars().cycle().take(len).collect();
+    format!(r#""{}""#, body)
+}
+
+fn gen_ascii_with_escapes(len: usize, interval: usize) -> String {
+    let mut body = String::with_capacity(len + len / interval * 2);
+    let base = "abcdefghijklmnopqrstuvwxyz";
+    let mut chars = base.chars().cycle();
+    for i in 0..len {
+        if i > 0 && i % interval == 0 {
+            body.push_str(r#"\""#);
+        } else {
+            body.push(chars.next().unwrap());
+        }
+    }
+    format!(r#""{}""#, body)
+}
+
+fn gen_many_short_keys(count: usize) -> String {
+    let mut s = String::from("{");
+    for i in 0..count {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&format!(r#""key{}":"val{}""#, i, i));
+    }
+    s.push('}');
+    s
+}
+
+fn gen_unicode_heavy(len: usize) -> String {
+    let chars = "あいうえおかきくけこ日本語テスト🎉🚀✨";
+    let body: String = chars.chars().cycle().take(len).collect();
+    format!(r#""{}""#, body)
+}
+
+fn gen_full_json_document() -> String {
+    let mut s = String::from(r#"{"users":["#);
+    for i in 0..50 {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&format!(
+            r#"{{"id":{},"name":"User {} with a reasonably long name for testing","email":"user{}@example.com","bio":"This is a biography text that contains several sentences. It is meant to test the performance of string parsing with typical content. Nothing special here, just plain ASCII text that goes on for a while to provide a realistic benchmark scenario.","active":true,"score":98.6}}"#,
+            i, i, i
+        ));
+    }
+    s.push_str("]}");
+    s
+}
+
+fn bench_parse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parse");
+
+    // Short ASCII string
+    let input = r#""hello""#.to_string();
+    group.bench_with_input(BenchmarkId::new("short_ascii", "5B"), &input, |b, input| {
+        b.iter(|| nojson::RawJson::parse(input).unwrap());
+    });
+
+    // Long ASCII, no escapes
+    for &len in &[64, 256, 1024] {
+        let input = gen_long_ascii(len);
+        group.bench_with_input(
+            BenchmarkId::new("long_ascii_no_escape", format!("{}B", len)),
+            &input,
+            |b, input| {
+                b.iter(|| nojson::RawJson::parse(input).unwrap());
+            },
+        );
+    }
+
+    // ASCII with periodic escapes
+    let input = gen_ascii_with_escapes(256, 32);
+    group.bench_with_input(
+        BenchmarkId::new("ascii_with_escapes", "256B/32"),
+        &input,
+        |b, input| {
+            b.iter(|| nojson::RawJson::parse(input).unwrap());
+        },
+    );
+
+    // Many short keys
+    let input = gen_many_short_keys(100);
+    group.bench_with_input(
+        BenchmarkId::new("many_short_keys", "100"),
+        &input,
+        |b, input| {
+            b.iter(|| nojson::RawJson::parse(input).unwrap());
+        },
+    );
+
+    // Unicode heavy
+    let input = gen_unicode_heavy(200);
+    group.bench_with_input(
+        BenchmarkId::new("unicode_heavy", "200ch"),
+        &input,
+        |b, input| {
+            b.iter(|| nojson::RawJson::parse(input).unwrap());
+        },
+    );
+
+    // Full JSON document
+    let input = gen_full_json_document();
+    group.bench_with_input(
+        BenchmarkId::new("full_json_document", "50users"),
+        &input,
+        |b, input| {
+            b.iter(|| nojson::RawJson::parse(input).unwrap());
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_parse);
+criterion_main!(benches);

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -38,6 +38,23 @@ fn gen_unicode_heavy(len: usize) -> String {
     format!(r#""{}""#, body)
 }
 
+fn gen_unicode_escapes(count: usize) -> String {
+    let mut s = String::with_capacity(2 + count * 6);
+    s.push('"');
+    for i in 0..count {
+        let code = match i % 4 {
+            0 => "3042", // あ
+            1 => "65e5", // 日
+            2 => "672c", // 本
+            _ => "8a9e", // 語
+        };
+        s.push_str(r#"\u"#);
+        s.push_str(code);
+    }
+    s.push('"');
+    s
+}
+
 fn gen_full_json_document() -> String {
     let mut s = String::from(r#"{"users":["#);
     for i in 0..50 {
@@ -98,6 +115,16 @@ fn bench_parse(c: &mut Criterion) {
     let input = gen_unicode_heavy(200);
     group.bench_with_input(
         BenchmarkId::new("unicode_heavy", "200ch"),
+        &input,
+        |b, input| {
+            b.iter(|| nojson::RawJson::parse(input).unwrap());
+        },
+    );
+
+    // Unicode escapes
+    let input = gen_unicode_escapes(128);
+    group.bench_with_input(
+        BenchmarkId::new("unicode_escapes", "128"),
         &input,
         |b, input| {
             b.iter(|| nojson::RawJson::parse(input).unwrap());

--- a/pbt/tests/test_proptest.rs
+++ b/pbt/tests/test_proptest.rs
@@ -11,6 +11,26 @@ use std::sync::Arc;
 use nojson::Json;
 use proptest::prelude::*;
 
+fn plain_ascii_string() -> impl Strategy<Value = String> {
+    prop::collection::vec(
+        prop_oneof![0x20u8..=0x21u8, 0x23u8..=0x5Bu8, 0x5Du8..=0x7Eu8],
+        1..8,
+    )
+    .prop_map(|bytes| bytes.into_iter().map(char::from).collect())
+}
+
+fn mixed_unicode_ascii_string() -> impl Strategy<Value = String> {
+    (
+        any::<String>(),
+        any::<char>().prop_filter("non-ASCII", |c| !c.is_ascii()),
+        plain_ascii_string(),
+        any::<String>(),
+    )
+        .prop_map(|(prefix, non_ascii, ascii, suffix)| {
+            format!("{prefix}{non_ascii}{ascii}{suffix}")
+        })
+}
+
 proptest! {
     #[test]
     fn roundtrip_bool(b: bool) {
@@ -105,6 +125,13 @@ proptest! {
 
     #[test]
     fn roundtrip_string(s: String) {
+        let json_str = Json(&s).to_string();
+        let parsed: Json<String> = json_str.parse().unwrap();
+        prop_assert_eq!(parsed.0, s);
+    }
+
+    #[test]
+    fn roundtrip_string_with_non_ascii_followed_by_ascii(s in mixed_unicode_ascii_string()) {
         let json_str = Json(&s).to_string();
         let parsed: Json<String> = json_str.parse().unwrap();
         prop_assert_eq!(parsed.0, s);

--- a/src/format.rs
+++ b/src/format.rs
@@ -270,18 +270,29 @@ struct JsonStringContentFormatter<'a, 'b> {
 
 impl core::fmt::Write for JsonStringContentFormatter<'_, '_> {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        for c in s.chars() {
-            match c {
-                '"' => write!(self.inner, r#"\""#)?,
-                '\\' => write!(self.inner, r#"\\"#)?,
-                '\n' => write!(self.inner, r#"\n"#)?,
-                '\r' => write!(self.inner, r#"\r"#)?,
-                '\t' => write!(self.inner, r#"\t"#)?,
-                '\u{0008}' => write!(self.inner, r#"\b"#)?,
-                '\u{000C}' => write!(self.inner, r#"\f"#)?,
-                _ if c.is_ascii_control() => write!(self.inner, "\\u{:04x}", c as u32)?,
-                _ => write!(self.inner, "{c}")?,
+        let bytes = s.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            let skip = crate::swar::skip_plain_ascii_bytes(&bytes[i..]);
+            if skip > 0 {
+                self.inner.write_str(&s[i..i + skip])?;
+                i += skip;
+                continue;
             }
+            // Current byte needs escaping or is non-ASCII
+            let c = s[i..].chars().next().unwrap();
+            match c {
+                '"' => self.inner.write_str("\\\"")?,
+                '\\' => self.inner.write_str("\\\\")?,
+                '\n' => self.inner.write_str("\\n")?,
+                '\r' => self.inner.write_str("\\r")?,
+                '\t' => self.inner.write_str("\\t")?,
+                '\u{0008}' => self.inner.write_str("\\b")?,
+                '\u{000C}' => self.inner.write_str("\\f")?,
+                _ if c.is_ascii_control() => write!(self.inner, "\\u{:04x}", c as u32)?,
+                _ => self.inner.write_str(&s[i..i + c.len_utf8()])?,
+            }
+            i += c.len_utf8();
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,7 @@ mod kind;
 mod parse;
 mod parse_error;
 mod raw;
+mod swar;
 mod try_from_impls;
 
 use core::{fmt::Display, str::FromStr};

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -288,28 +288,40 @@ impl<'a, E: Extensions> JsonParser<'a, E> {
         loop {
             let skip = crate::swar::skip_plain_ascii_bytes(s.as_bytes());
             s = &s[skip..];
-            // Skip non-ASCII chars (SWAR stops at bytes >= 0x80, but they are valid in JSON strings)
-            s = s.trim_start_matches(|c: char| !c.is_ascii());
-            if let Some(s) = s.strip_prefix('"') {
-                self.push_entry(self.offset(s));
-                self.values.last_mut().expect("infallible").escaped = escaped;
-                return Ok(());
-            }
-
-            escaped = true;
-            s = self.strip_char(s, '\\')?;
-            if let Some(suffix) = s.strip_prefix(['"', '\\', '/', 'n', 't', 'r', 'b', 'f']) {
-                s = suffix;
-            } else {
-                s = self.strip_char(s, 'u')?;
-                if s.len() < 4 {
+            match s.chars().next() {
+                Some('"') => {
+                    let s = &s['"'.len_utf8()..];
+                    self.push_entry(self.offset(s));
+                    self.values.last_mut().expect("infallible").escaped = escaped;
+                    return Ok(());
+                }
+                Some('\\') => {
+                    escaped = true;
+                    s = &s['\\'.len_utf8()..];
+                    if let Some(suffix) = s.strip_prefix(['"', '\\', '/', 'n', 't', 'r', 'b', 'f'])
+                    {
+                        s = suffix;
+                    } else {
+                        s = self.strip_char(s, 'u')?;
+                        if s.len() < 4 {
+                            return Err(self.unexpected_eos());
+                        }
+                        s.get(0..4)
+                            .and_then(|code| u32::from_str_radix(code, 16).ok())
+                            .and_then(char::from_u32)
+                            .ok_or_else(|| self.unexpected_value_char(self.offset(s)))?;
+                        s = &s[4..];
+                    }
+                }
+                Some(ch) if !ch.is_ascii() => {
+                    s = &s[ch.len_utf8()..];
+                }
+                Some(_) => {
+                    return Err(self.unexpected_value_char(self.offset(s)));
+                }
+                None => {
                     return Err(self.unexpected_eos());
                 }
-                s.get(0..4)
-                    .and_then(|code| u32::from_str_radix(code, 16).ok())
-                    .and_then(char::from_u32)
-                    .ok_or_else(|| self.unexpected_value_char(self.offset(s)))?;
-                s = &s[4..];
             }
         }
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -286,7 +286,10 @@ impl<'a, E: Extensions> JsonParser<'a, E> {
         self.kind = Some(JsonValueKind::String);
 
         loop {
-            s = s.trim_start_matches(|c| !(matches!(c, '"' | '\\') || c.is_ascii_control()));
+            let skip = crate::swar::skip_plain_ascii_bytes(s.as_bytes());
+            s = &s[skip..];
+            // Skip non-ASCII chars (SWAR stops at bytes >= 0x80, but they are valid in JSON strings)
+            s = s.trim_start_matches(|c: char| !c.is_ascii());
             if let Some(s) = s.strip_prefix('"') {
                 self.push_entry(self.offset(s));
                 self.values.last_mut().expect("infallible").escaped = escaped;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -288,16 +288,21 @@ impl<'a, E: Extensions> JsonParser<'a, E> {
         loop {
             let skip = crate::swar::skip_plain_ascii_bytes(s.as_bytes());
             s = &s[skip..];
-            match s.chars().next() {
-                Some('"') => {
-                    let s = &s['"'.len_utf8()..];
+            let skip = crate::swar::skip_non_ascii_bytes(s.as_bytes());
+            if skip > 0 {
+                s = &s[skip..];
+                continue;
+            }
+            match s.as_bytes().first().copied() {
+                Some(b'"') => {
+                    let s = &s[1..];
                     self.push_entry(self.offset(s));
                     self.values.last_mut().expect("infallible").escaped = escaped;
                     return Ok(());
                 }
-                Some('\\') => {
+                Some(b'\\') => {
                     escaped = true;
-                    s = &s['\\'.len_utf8()..];
+                    s = &s[1..];
                     if let Some(suffix) = s.strip_prefix(['"', '\\', '/', 'n', 't', 'r', 'b', 'f'])
                     {
                         s = suffix;
@@ -306,15 +311,10 @@ impl<'a, E: Extensions> JsonParser<'a, E> {
                         if s.len() < 4 {
                             return Err(self.unexpected_eos());
                         }
-                        s.get(0..4)
-                            .and_then(|code| u32::from_str_radix(code, 16).ok())
-                            .and_then(char::from_u32)
+                        decode_hex_char(s)
                             .ok_or_else(|| self.unexpected_value_char(self.offset(s)))?;
                         s = &s[4..];
                     }
-                }
-                Some(ch) if !ch.is_ascii() => {
-                    s = &s[ch.len_utf8()..];
                 }
                 Some(_) => {
                     return Err(self.unexpected_value_char(self.offset(s)));
@@ -359,5 +359,25 @@ impl<'a, E: Extensions> JsonParser<'a, E> {
             kind: self.kind,
             position: self.original_text.len(),
         }
+    }
+}
+
+#[inline(always)]
+fn decode_hex_char(s: &str) -> Option<char> {
+    let bytes = s.as_bytes().get(..4)?;
+    let mut code = 0u32;
+    for &byte in bytes {
+        code = (code << 4) | decode_hex_nibble(byte)?;
+    }
+    char::from_u32(code)
+}
+
+#[inline(always)]
+fn decode_hex_nibble(byte: u8) -> Option<u32> {
+    match byte {
+        b'0'..=b'9' => Some((byte - b'0') as u32),
+        b'a'..=b'f' => Some((byte - b'a' + 10) as u32),
+        b'A'..=b'F' => Some((byte - b'A' + 10) as u32),
+        _ => None,
     }
 }

--- a/src/swar.rs
+++ b/src/swar.rs
@@ -40,6 +40,19 @@ pub(crate) fn skip_plain_ascii_bytes(s: &[u8]) -> usize {
     i
 }
 
+/// Returns the number of leading bytes in `s` that belong to a non-ASCII UTF-8 run.
+///
+/// This assumes `s` starts at a UTF-8 character boundary. It stops at the first ASCII byte,
+/// which is also a character boundary in valid UTF-8.
+#[inline(always)]
+pub(crate) fn skip_non_ascii_bytes(s: &[u8]) -> usize {
+    let mut i = 0;
+    while i < s.len() && s[i] & 0x80 != 0 {
+        i += 1;
+    }
+    i
+}
+
 /// Check if all 8 bytes in `w` are plain ASCII for JSON strings.
 #[inline(always)]
 fn is_all_plain_ascii(w: u64) -> bool {
@@ -182,6 +195,13 @@ mod tests {
     fn non_ascii_stops() {
         assert_eq!(skip_plain_ascii_bytes("abc日本語".as_bytes()), 3);
         assert_eq!(skip_plain_ascii_bytes("あ".as_bytes()), 0);
+    }
+
+    #[test]
+    fn non_ascii_run() {
+        assert_eq!(skip_non_ascii_bytes("日本語x".as_bytes()), "日本語".len());
+        assert_eq!(skip_non_ascii_bytes("あa".as_bytes()), "あ".len());
+        assert_eq!(skip_non_ascii_bytes("abc".as_bytes()), 0);
     }
 
     #[test]

--- a/src/swar.rs
+++ b/src/swar.rs
@@ -47,65 +47,57 @@ pub(crate) fn skip_plain_ascii_bytes(s: &[u8]) -> usize {
 #[inline(always)]
 pub(crate) fn skip_non_ascii_bytes(s: &[u8]) -> usize {
     let mut i = 0;
+
+    // Process 8 bytes at a time: all non-ASCII bytes have bit 7 set
+    while i + 8 <= s.len() {
+        let chunk: [u8; 8] = s[i..i + 8].try_into().unwrap();
+        let w = u64::from_ne_bytes(chunk);
+        if w & MASK_80 == MASK_80 {
+            i += 8;
+        } else {
+            break;
+        }
+    }
+
     while i < s.len() && s[i] & 0x80 != 0 {
         i += 1;
     }
     i
 }
 
+/// Build a mask with bit 7 set for each byte in `w` that is NOT plain ASCII for JSON strings.
+/// A byte is non-plain if: >= 128, < 32, == 0x22 (`"`), or == 0x5C (`\`).
+#[inline(always)]
+fn non_plain_mask(w: u64) -> u64 {
+    // Non-ASCII: byte >= 128
+    let non_ascii = w & MASK_80;
+
+    // Control chars: byte < 32 (for bytes < 128)
+    // For b in [0x00, 0x7F]: b + 0x60 sets bit 7 iff b >= 0x20
+    let control = (w.wrapping_add(0x6060606060606060) ^ MASK_80) & MASK_80;
+
+    // Quote (0x22): Mycroft's zero-byte detection
+    let xor_quote = w ^ 0x2222222222222222;
+    let quote = xor_quote.wrapping_sub(MASK_01) & !xor_quote & MASK_80;
+
+    // Backslash (0x5C): Mycroft's zero-byte detection
+    let xor_bslash = w ^ 0x5C5C5C5C5C5C5C5C;
+    let bslash = xor_bslash.wrapping_sub(MASK_01) & !xor_bslash & MASK_80;
+
+    non_ascii | control | quote | bslash
+}
+
 /// Check if all 8 bytes in `w` are plain ASCII for JSON strings.
 #[inline(always)]
 fn is_all_plain_ascii(w: u64) -> bool {
-    // 1. All bytes < 128 (ASCII)
-    if w & MASK_80 != 0 {
-        return false;
-    }
-
-    // 2. All bytes >= 32 (no control chars)
-    //    For b in [0x00, 0x7F]: b + 0x60 sets bit 7 iff b >= 0x20
-    if (w.wrapping_add(0x6060606060606060)) & MASK_80 != MASK_80 {
-        return false;
-    }
-
-    // 3. No double quote (0x22) — Mycroft's zero-byte detection
-    //    Since all bytes < 128 (check 1), we can omit the `& !xor` term
-    let xor_quote = w ^ 0x2222222222222222;
-    if (xor_quote.wrapping_sub(MASK_01)) & MASK_80 != 0 {
-        return false;
-    }
-
-    // 4. No backslash (0x5C)
-    let xor_bslash = w ^ 0x5C5C5C5C5C5C5C5C;
-    if (xor_bslash.wrapping_sub(MASK_01)) & MASK_80 != 0 {
-        return false;
-    }
-
-    true
+    non_plain_mask(w) == 0
 }
 
 /// Find the byte offset of the first non-plain byte within a u64 word.
 /// Assumes at least one non-plain byte exists.
 #[inline(always)]
 fn first_non_plain_offset(w: u64) -> usize {
-    // Build a mask with bit 7 set for each byte that is NOT plain.
-    // A byte is non-plain if: >= 128, < 32, == 0x22, or == 0x5C.
-
-    // Non-ASCII: byte >= 128
-    let non_ascii = w & MASK_80;
-
-    // Control chars: byte < 32 (given byte < 128)
-    // (w + 0x60) & 0x80 == 0 means byte < 0x20
-    let control = (w.wrapping_add(0x6060606060606060) ^ MASK_80) & MASK_80;
-
-    // Quote: Mycroft detection
-    let xor_quote = w ^ 0x2222222222222222;
-    let quote = xor_quote.wrapping_sub(MASK_01) & !xor_quote & MASK_80;
-
-    // Backslash: Mycroft detection
-    let xor_bslash = w ^ 0x5C5C5C5C5C5C5C5C;
-    let bslash = xor_bslash.wrapping_sub(MASK_01) & !xor_bslash & MASK_80;
-
-    let fail = non_ascii | control | quote | bslash;
+    let fail = non_plain_mask(w);
 
     // Find the first set bit. On little-endian, trailing_zeros gives the
     // lowest-address byte. On big-endian, leading_zeros does.

--- a/src/swar.rs
+++ b/src/swar.rs
@@ -108,7 +108,7 @@ fn first_non_plain_offset(w: u64) -> usize {
 
 #[inline(always)]
 fn is_plain_ascii_byte(b: u8) -> bool {
-    b >= 0x20 && b < 0x80 && b != b'"' && b != b'\\'
+    (0x20..0x80).contains(&b) && b != b'"' && b != b'\\'
 }
 
 #[cfg(test)]
@@ -138,7 +138,7 @@ mod tests {
     #[test]
     fn quote_at_various_positions() {
         for pos in 0..16 {
-            let mut buf = vec![b'a'; 16];
+            let mut buf = [b'a'; 16];
             buf[pos] = b'"';
             assert_eq!(
                 skip_plain_ascii_bytes(&buf),
@@ -152,7 +152,7 @@ mod tests {
     #[test]
     fn backslash_at_various_positions() {
         for pos in 0..16 {
-            let mut buf = vec![b'a'; 16];
+            let mut buf = [b'a'; 16];
             buf[pos] = b'\\';
             assert_eq!(
                 skip_plain_ascii_bytes(&buf),
@@ -167,12 +167,7 @@ mod tests {
     fn control_chars() {
         for b in 0..0x20u8 {
             let buf = [b'a', b'b', b'c', b];
-            assert_eq!(
-                skip_plain_ascii_bytes(&buf),
-                3,
-                "control char 0x{:02x}",
-                b
-            );
+            assert_eq!(skip_plain_ascii_bytes(&buf), 3, "control char 0x{:02x}", b);
         }
     }
 
@@ -230,8 +225,12 @@ mod tests {
 
     #[test]
     fn long_plain_then_special() {
-        let mut buf = vec![b'x'; 1024];
-        buf[1000] = b'"';
-        assert_eq!(skip_plain_ascii_bytes(&buf), 1000);
+        let buf = [b'x'; 1024];
+        // All 1024 bytes are plain 'x'
+        assert_eq!(skip_plain_ascii_bytes(&buf), 1024);
+
+        let mut buf2 = [b'x'; 64];
+        buf2[50] = b'"';
+        assert_eq!(skip_plain_ascii_bytes(&buf2), 50);
     }
 }

--- a/src/swar.rs
+++ b/src/swar.rs
@@ -1,0 +1,237 @@
+//! SWAR (SIMD Within A Register) optimization for JSON string scanning.
+//!
+//! Checks 8 bytes at a time using bitwise operations on a `u64` to find
+//! bytes that require special handling in JSON strings: control characters
+//! (< 0x20), double quote (0x22), and backslash (0x5C).
+
+const MASK_80: u64 = 0x8080808080808080;
+const MASK_01: u64 = 0x0101010101010101;
+
+/// Returns the number of leading bytes in `s` that are "plain" ASCII for JSON strings:
+/// - Not a control character (byte >= 0x20)
+/// - Not a double quote `"` (0x22)
+/// - Not a backslash `\` (0x5C)
+/// - ASCII (byte < 0x80), so byte/char boundaries are guaranteed to align
+pub(crate) fn skip_plain_ascii_bytes(s: &[u8]) -> usize {
+    let mut i = 0;
+
+    // Process 8 bytes at a time
+    while i + 8 <= s.len() {
+        let chunk: [u8; 8] = s[i..i + 8].try_into().unwrap();
+        let w = u64::from_ne_bytes(chunk);
+
+        if is_all_plain_ascii(w) {
+            i += 8;
+        } else {
+            // Find the first non-plain byte within this chunk
+            return i + first_non_plain_offset(w);
+        }
+    }
+
+    // Handle remaining bytes (< 8)
+    while i < s.len() {
+        if is_plain_ascii_byte(s[i]) {
+            i += 1;
+        } else {
+            break;
+        }
+    }
+
+    i
+}
+
+/// Check if all 8 bytes in `w` are plain ASCII for JSON strings.
+#[inline(always)]
+fn is_all_plain_ascii(w: u64) -> bool {
+    // 1. All bytes < 128 (ASCII)
+    if w & MASK_80 != 0 {
+        return false;
+    }
+
+    // 2. All bytes >= 32 (no control chars)
+    //    For b in [0x00, 0x7F]: b + 0x60 sets bit 7 iff b >= 0x20
+    if (w.wrapping_add(0x6060606060606060)) & MASK_80 != MASK_80 {
+        return false;
+    }
+
+    // 3. No double quote (0x22) — Mycroft's zero-byte detection
+    //    Since all bytes < 128 (check 1), we can omit the `& !xor` term
+    let xor_quote = w ^ 0x2222222222222222;
+    if (xor_quote.wrapping_sub(MASK_01)) & MASK_80 != 0 {
+        return false;
+    }
+
+    // 4. No backslash (0x5C)
+    let xor_bslash = w ^ 0x5C5C5C5C5C5C5C5C;
+    if (xor_bslash.wrapping_sub(MASK_01)) & MASK_80 != 0 {
+        return false;
+    }
+
+    true
+}
+
+/// Find the byte offset of the first non-plain byte within a u64 word.
+/// Assumes at least one non-plain byte exists.
+#[inline(always)]
+fn first_non_plain_offset(w: u64) -> usize {
+    // Build a mask with bit 7 set for each byte that is NOT plain.
+    // A byte is non-plain if: >= 128, < 32, == 0x22, or == 0x5C.
+
+    // Non-ASCII: byte >= 128
+    let non_ascii = w & MASK_80;
+
+    // Control chars: byte < 32 (given byte < 128)
+    // (w + 0x60) & 0x80 == 0 means byte < 0x20
+    let control = (w.wrapping_add(0x6060606060606060) ^ MASK_80) & MASK_80;
+
+    // Quote: Mycroft detection
+    let xor_quote = w ^ 0x2222222222222222;
+    let quote = xor_quote.wrapping_sub(MASK_01) & !xor_quote & MASK_80;
+
+    // Backslash: Mycroft detection
+    let xor_bslash = w ^ 0x5C5C5C5C5C5C5C5C;
+    let bslash = xor_bslash.wrapping_sub(MASK_01) & !xor_bslash & MASK_80;
+
+    let fail = non_ascii | control | quote | bslash;
+
+    // Find the first set bit. On little-endian, trailing_zeros gives the
+    // lowest-address byte. On big-endian, leading_zeros does.
+    #[cfg(target_endian = "little")]
+    {
+        (fail.trailing_zeros() / 8) as usize
+    }
+    #[cfg(target_endian = "big")]
+    {
+        (fail.leading_zeros() / 8) as usize
+    }
+}
+
+#[inline(always)]
+fn is_plain_ascii_byte(b: u8) -> bool {
+    b >= 0x20 && b < 0x80 && b != b'"' && b != b'\\'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty() {
+        assert_eq!(skip_plain_ascii_bytes(b""), 0);
+    }
+
+    #[test]
+    fn all_plain_short() {
+        assert_eq!(skip_plain_ascii_bytes(b"hello"), 5);
+    }
+
+    #[test]
+    fn all_plain_8_bytes() {
+        assert_eq!(skip_plain_ascii_bytes(b"abcdefgh"), 8);
+    }
+
+    #[test]
+    fn all_plain_16_bytes() {
+        assert_eq!(skip_plain_ascii_bytes(b"abcdefghijklmnop"), 16);
+    }
+
+    #[test]
+    fn quote_at_various_positions() {
+        for pos in 0..16 {
+            let mut buf = vec![b'a'; 16];
+            buf[pos] = b'"';
+            assert_eq!(
+                skip_plain_ascii_bytes(&buf),
+                pos,
+                "quote at position {}",
+                pos
+            );
+        }
+    }
+
+    #[test]
+    fn backslash_at_various_positions() {
+        for pos in 0..16 {
+            let mut buf = vec![b'a'; 16];
+            buf[pos] = b'\\';
+            assert_eq!(
+                skip_plain_ascii_bytes(&buf),
+                pos,
+                "backslash at position {}",
+                pos
+            );
+        }
+    }
+
+    #[test]
+    fn control_chars() {
+        for b in 0..0x20u8 {
+            let buf = [b'a', b'b', b'c', b];
+            assert_eq!(
+                skip_plain_ascii_bytes(&buf),
+                3,
+                "control char 0x{:02x}",
+                b
+            );
+        }
+    }
+
+    #[test]
+    fn control_char_at_start() {
+        assert_eq!(skip_plain_ascii_bytes(b"\x00abc"), 0);
+        assert_eq!(skip_plain_ascii_bytes(b"\nabc"), 0);
+        assert_eq!(skip_plain_ascii_bytes(b"\tabc"), 0);
+    }
+
+    #[test]
+    fn non_ascii_stops() {
+        assert_eq!(skip_plain_ascii_bytes("abc日本語".as_bytes()), 3);
+        assert_eq!(skip_plain_ascii_bytes("あ".as_bytes()), 0);
+    }
+
+    #[test]
+    fn high_ascii_boundary() {
+        // 0x7F (DEL) is a control char in JSON context? No, JSON spec says < 0x20 are control.
+        // DEL (0x7F) is technically a control char but JSON spec only requires escaping < 0x20.
+        // Our function treats 0x7F as plain ASCII (>= 0x20 and < 0x80).
+        assert_eq!(skip_plain_ascii_bytes(&[0x7F]), 1);
+        // 0x80 is non-ASCII
+        assert_eq!(skip_plain_ascii_bytes(&[0x80]), 0);
+        // 0x20 (space) is the first plain byte
+        assert_eq!(skip_plain_ascii_bytes(&[0x20]), 1);
+        // 0x1F is last control char
+        assert_eq!(skip_plain_ascii_bytes(&[0x1F]), 0);
+    }
+
+    #[test]
+    fn mixed_content() {
+        let input = b"Hello, World!\"rest";
+        assert_eq!(skip_plain_ascii_bytes(input), 13); // stops at "
+    }
+
+    #[test]
+    fn all_printable_ascii() {
+        // All printable ASCII except " and \ should be plain
+        let mut count = 0;
+        for b in 0x20..0x80u8 {
+            if b != b'"' && b != b'\\' {
+                assert_eq!(
+                    skip_plain_ascii_bytes(&[b]),
+                    1,
+                    "byte 0x{:02x} ('{}') should be plain",
+                    b,
+                    b as char,
+                );
+                count += 1;
+            }
+        }
+        assert_eq!(count, 94); // 96 printable minus " and \
+    }
+
+    #[test]
+    fn long_plain_then_special() {
+        let mut buf = vec![b'x'; 1024];
+        buf[1000] = b'"';
+        assert_eq!(skip_plain_ascii_bytes(&buf), 1000);
+    }
+}

--- a/tests/test_jsonc.rs
+++ b/tests/test_jsonc.rs
@@ -116,7 +116,7 @@ fn parse_jsonc_trailing_commas_object() -> Result<(), JsonParseError> {
     assert_eq!(age, 30);
 
     let active: bool = json.value().to_member("active")?.required()?.try_into()?;
-    assert_eq!(active, true);
+    assert!(active);
 
     Ok(())
 }
@@ -173,7 +173,7 @@ fn parse_jsonc_trailing_commas_with_comments() -> Result<(), JsonParseError> {
         .to_member("debug")?
         .required()?
         .try_into()?;
-    assert_eq!(debug, true);
+    assert!(debug);
 
     let port: i32 = json
         .value()

--- a/tests/test_parse.rs
+++ b/tests/test_parse.rs
@@ -180,7 +180,12 @@ fn parse_numbers() -> Result<(), JsonParseError> {
 #[test]
 fn parse_strings() -> Result<(), JsonParseError> {
     // Non-escaped strings.
-    for text in [r#" "" "#, r#" "abc" "#] {
+    for (text, unescaped) in [
+        (r#" "" "#, ""),
+        (r#" "abc" "#, "abc"),
+        (r#" "あa" "#, "あa"),
+        (r#" "日本語x" "#, "日本語x"),
+    ] {
         let json = RawJson::parse(text)?;
         let value = json.value();
         assert_eq!(value.kind(), JsonValueKind::String);
@@ -190,6 +195,7 @@ fn parse_strings() -> Result<(), JsonParseError> {
             value.to_unquoted_string_str(),
             Ok(Cow::Borrowed(_))
         ));
+        assert_eq!(value.to_unquoted_string_str()?, unescaped);
     }
 
     // Escaped strings.


### PR DESCRIPTION
This PR optimizes JSON string processing with a SWAR-based fast path.

It also improves \uXXXX escape decoding performance, adds regression coverage for mixed Unicode/ASCII strings, and adds benchmarks for Unicode-heavy cases.

## What Changed

- Optimized string parsing to:
    - skip plain ASCII runs with SWAR
    - skip non-ASCII UTF-8 runs efficiently
    - handle " / \ with byte-based branching
- Replaced u32::from_str_radix(..., 16) for \uXXXX parsing with a fixed-width hex decoder.
- Added regression tests for mixed Unicode/ASCII strings.
- Added a dedicated proptest case for strings containing non-ASCII followed by ASCII.
- Added benchmark cases for Unicode-heavy parsing, \uXXXX-heavy parsing, and Unicode-heavy formatting.

## About SWAR

SWAR stands for "SIMD Within A Register".

Here it is used to scan 8 bytes at a time and quickly skip JSON string bytes that are plain ASCII and do not need special handling. This keeps the hot path fast without relying on platform-specific SIMD intrinsics.

## Benchmark

### How To Run

```sh
cargo bench --bench parse -- --noplot
cargo bench --bench format -- --noplot
```

### Results

Measured against main using the same benchmark harness in a temporary main worktree.

| Benchmark | main | this PR | Change |
| --- | ---: | ---: | ---: |
| parse/short_ascii/5B | 37.04 ns | 36.99 ns | ~0% |
| parse/long_ascii_no_escape/64B | 96.78 ns | 41.56 ns | -57% |
| parse/long_ascii_no_escape/256B | 290.32 ns | 65.43 ns | -77% |
| parse/long_ascii_no_escape/1024B | 1.062 µs | 166.30 ns | -84% |
| parse/ascii_with_escapes/256B/32 | 296.85 ns | 95.12 ns | -68% |
| parse/many_short_keys/100 | 3.072 µs | 2.700 µs | -12% |
| parse/unicode_heavy/200ch | 305.78 ns | 256.53 ns | -16% |
| parse/unicode_escapes/128 | 698.96 ns | 647.42 ns | -7% |
| parse/full_json_document/50users | 24.023 µs | 9.551 µs | -60% |
| format/plain_ascii/64B | 601.98 ns | 103.79 ns | -83% |
| format/plain_ascii/256B | 1.944 µs | 177.39 ns | -91% |
| format/plain_ascii/1024B | 7.054 µs | 286.48 ns | -96% |
| format/mixed_escapes/256B | 1.969 µs | 633.36 ns | -68% |
| format/unicode_heavy/200ch | 1.960 µs | 2.186 µs | +12% |
| format/object_formatting/50pairs | 31.505 µs | 3.313 µs | -89% |

### Takeaway

- Parsing is faster than main across all measured parse cases.
- The largest wins are on long ASCII strings, escape-heavy strings, and full document parsing.
- Formatting is much faster than main in most measured cases, while unicode_heavy formatting is slightly slower.

