### PR TITLE
Speed up parse and format with SWAR scanning helpers

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -54,9 +54,30 @@ jobs:
           fi
 
       - name: Run benchmark
+        # ubuntu-latest runners use a mix of CPU generations (Skylake /
+        # Cascade Lake / Ice Lake / Sapphire Rapids — different Azure VM
+        # SKUs). Performance can vary up to ~10-15% between generations,
+        # which can swamp small optimizations and look like uniform
+        # regressions/wins across unrelated cases. When aggregating
+        # multiple runs (e.g., A/B comparing two branches), grep the
+        # `cpu:` line from each artifact's bench.txt and group runs by
+        # CPU model before computing best-of-N. macos-latest runners are
+        # M1, so they're consistent and don't need this treatment.
         env:
           BENCH_REPEATS: ${{ inputs.repeats }}
-        run: cargo run --release --example benchmark | tee bench.txt
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            cpu=$(lscpu | awk -F': +' '/^Model name/ {print $2; exit}')
+          else
+            cpu=$(sysctl -n machdep.cpu.brand_string)
+          fi
+          {
+            echo "cpu: $cpu"
+            echo "os: $RUNNER_OS $RUNNER_ARCH"
+            echo "rustc: $(rustc --version)"
+            echo
+            cargo run --release --example benchmark
+          } | tee bench.txt
 
       - name: Upload results
         uses: actions/upload-artifact@v4

--- a/src/format.rs
+++ b/src/format.rs
@@ -279,20 +279,30 @@ impl core::fmt::Write for JsonStringContentFormatter<'_, '_> {
                 i += skip;
                 continue;
             }
-            // Current byte needs escaping or is non-ASCII
-            let c = s[i..].chars().next().unwrap();
-            match c {
-                '"' => self.inner.write_str("\\\"")?,
-                '\\' => self.inner.write_str("\\\\")?,
-                '\n' => self.inner.write_str("\\n")?,
-                '\r' => self.inner.write_str("\\r")?,
-                '\t' => self.inner.write_str("\\t")?,
-                '\u{0008}' => self.inner.write_str("\\b")?,
-                '\u{000C}' => self.inner.write_str("\\f")?,
-                _ if c.is_ascii_control() => write!(self.inner, "\\u{:04x}", c as u32)?,
-                _ => self.inner.write_str(&s[i..i + c.len_utf8()])?,
+            // Non-ASCII bytes don't need escaping in JSON; emit the entire
+            // contiguous non-ASCII run in one write_str rather than
+            // re-decoding char-by-char. Safe because `s` is valid UTF-8 and
+            // `skip_non_ascii_bytes` stops at the next ASCII byte, which is
+            // also a UTF-8 boundary.
+            if bytes[i] >= 0x80 {
+                let run = crate::swar::skip_non_ascii_bytes(&bytes[i..]);
+                self.inner.write_str(&s[i..i + run])?;
+                i += run;
+                continue;
             }
-            i += c.len_utf8();
+            // ASCII byte that needs escaping: ", \, or a control character.
+            let b = bytes[i];
+            match b {
+                b'"' => self.inner.write_str("\\\"")?,
+                b'\\' => self.inner.write_str("\\\\")?,
+                b'\n' => self.inner.write_str("\\n")?,
+                b'\r' => self.inner.write_str("\\r")?,
+                b'\t' => self.inner.write_str("\\t")?,
+                0x08 => self.inner.write_str("\\b")?,
+                0x0C => self.inner.write_str("\\f")?,
+                _ => write!(self.inner, "\\u{:04x}", b as u32)?,
+            }
+            i += 1;
         }
         Ok(())
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -6,8 +6,6 @@ use crate::{
     raw::{JsonParseError, JsonValueIndexEntry},
 };
 
-const WHITESPACE_PATTERN: [char; 4] = [' ', '\t', '\r', '\n'];
-
 pub trait Extensions {
     const ALLOW_COMMENTS: bool;
     const ALLOW_TRAILING_COMMAS: bool;
@@ -71,7 +69,7 @@ impl<'a, E: Extensions> JsonParser<'a, E> {
     }
 
     fn skip_whitespaces_and_comments(&mut self, s: &'a str) -> Result<&'a str, JsonParseError> {
-        let mut s = s.trim_start_matches(WHITESPACE_PATTERN);
+        let mut s = &s[crate::swar::skip_json_whitespace(s.as_bytes())..];
         if !E::ALLOW_COMMENTS {
             return Ok(s);
         }
@@ -92,7 +90,7 @@ impl<'a, E: Extensions> JsonParser<'a, E> {
 
             let end = self.original_text.len() - s.len();
             self.comments.push(Range { start, end });
-            s = s.trim_start_matches(WHITESPACE_PATTERN);
+            s = &s[crate::swar::skip_json_whitespace(s.as_bytes())..];
         }
         Ok(s)
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -195,10 +195,12 @@ impl<'a, E: Extensions> JsonParser<'a, E> {
     }
 
     fn strip_one_or_more_digits(&self, s: &'a str) -> Result<&'a str, JsonParseError> {
-        let digits = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
-        s.strip_prefix(digits)
-            .ok_or_else(|| self.unexpected_value_char(self.offset(s)))
-            .map(|s| s.trim_start_matches(digits))
+        let n = crate::swar::skip_ascii_digits(s.as_bytes());
+        if n == 0 {
+            Err(self.unexpected_value_char(self.offset(s)))
+        } else {
+            Ok(&s[n..])
+        }
     }
 
     fn parse_object(&mut self, s: &'a str) -> Result<(), JsonParseError> {

--- a/src/swar.rs
+++ b/src/swar.rs
@@ -65,6 +65,67 @@ pub(crate) fn skip_non_ascii_bytes(s: &[u8]) -> usize {
     i
 }
 
+/// Returns the number of leading bytes in `s` that are ASCII digits (`'0'..='9'`).
+pub(crate) fn skip_ascii_digits(s: &[u8]) -> usize {
+    let mut i = 0;
+
+    // Process 8 bytes at a time.
+    while i + 8 <= s.len() {
+        let chunk: [u8; 8] = s[i..i + 8].try_into().unwrap();
+        let w = u64::from_ne_bytes(chunk);
+
+        if is_all_ascii_digits(w) {
+            i += 8;
+        } else {
+            return i + first_non_digit_offset(w);
+        }
+    }
+
+    while i < s.len() && s[i].is_ascii_digit() {
+        i += 1;
+    }
+
+    i
+}
+
+/// Build a mask with bit 7 set for each byte in `w` that is NOT an ASCII digit.
+/// A byte is non-digit if: byte < 0x30, byte > 0x39, or byte >= 0x80.
+#[inline(always)]
+fn non_digit_mask(w: u64) -> u64 {
+    // Non-ASCII: byte >= 0x80
+    let non_ascii = w & MASK_80;
+
+    // byte < 0x30: b + 0x50 has bit 7 set iff b >= 0x30 (within ASCII).
+    // XOR with MASK_80 inverts so bit 7 set iff b < 0x30.
+    let lt_30 = (w.wrapping_add(0x5050505050505050) ^ MASK_80) & MASK_80;
+
+    // byte > 0x39 (within ASCII): b + 0x46 has bit 7 set iff b >= 0x3A.
+    // For non-ASCII (b >= 0x80), addition can wrap; that case is covered by
+    // `non_ascii`, and any spurious carry into a later byte is harmless
+    // because we only report the first non-digit position.
+    let gt_39 = w.wrapping_add(0x4646464646464646) & MASK_80;
+
+    non_ascii | lt_30 | gt_39
+}
+
+#[inline(always)]
+fn is_all_ascii_digits(w: u64) -> bool {
+    non_digit_mask(w) == 0
+}
+
+#[inline(always)]
+fn first_non_digit_offset(w: u64) -> usize {
+    let fail = non_digit_mask(w);
+    #[cfg(target_endian = "little")]
+    {
+        (fail.trailing_zeros() / 8) as usize
+    }
+    #[cfg(target_endian = "big")]
+    {
+        (fail.leading_zeros() / 8) as usize
+    }
+}
+
 /// Build a mask with bit 7 set for each byte in `w` that is NOT plain ASCII for JSON strings.
 /// A byte is non-plain if: >= 128, < 32, == 0x22 (`"`), or == 0x5C (`\`).
 #[inline(always)]
@@ -244,5 +305,63 @@ mod tests {
         let mut buf2 = [b'x'; 64];
         buf2[50] = b'"';
         assert_eq!(skip_plain_ascii_bytes(&buf2), 50);
+    }
+
+    #[test]
+    fn digits_empty_and_short() {
+        assert_eq!(skip_ascii_digits(b""), 0);
+        assert_eq!(skip_ascii_digits(b"0"), 1);
+        assert_eq!(skip_ascii_digits(b"9"), 1);
+        assert_eq!(skip_ascii_digits(b"a"), 0);
+        assert_eq!(skip_ascii_digits(b"123"), 3);
+    }
+
+    #[test]
+    fn digits_full_chunk() {
+        assert_eq!(skip_ascii_digits(b"01234567"), 8);
+        assert_eq!(skip_ascii_digits(b"0123456789012345"), 16);
+    }
+
+    #[test]
+    fn digits_stop_at_non_digit() {
+        assert_eq!(skip_ascii_digits(b"12345abc"), 5);
+        assert_eq!(skip_ascii_digits(b"1234567a"), 7);
+        assert_eq!(skip_ascii_digits(b"12345678a"), 8);
+        assert_eq!(skip_ascii_digits(b"123456789a"), 9);
+    }
+
+    #[test]
+    fn digits_boundary_chars() {
+        // '/' = 0x2F, just below '0' = 0x30
+        assert_eq!(skip_ascii_digits(b"/"), 0);
+        // ':' = 0x3A, just above '9' = 0x39
+        assert_eq!(skip_ascii_digits(b":"), 0);
+        // '0' boundary
+        assert_eq!(skip_ascii_digits(b"0/"), 1);
+        // '9' boundary
+        assert_eq!(skip_ascii_digits(b"9:"), 1);
+    }
+
+    #[test]
+    fn digits_non_ascii() {
+        // Non-ASCII byte stops the run.
+        let mut buf = b"12345\xC2\xA00".to_vec();
+        assert_eq!(skip_ascii_digits(&buf), 5);
+        // Non-ASCII at start.
+        buf = b"\xFF1234".to_vec();
+        assert_eq!(skip_ascii_digits(&buf), 0);
+    }
+
+    #[test]
+    fn digits_each_non_digit_position() {
+        for pos in 0..16 {
+            let mut buf = [b'5'; 16];
+            buf[pos] = b'.';
+            assert_eq!(
+                skip_ascii_digits(&buf),
+                pos,
+                "non-digit '.' at position {pos}"
+            );
+        }
     }
 }

--- a/src/swar.rs
+++ b/src/swar.rs
@@ -65,6 +65,22 @@ pub(crate) fn skip_non_ascii_bytes(s: &[u8]) -> usize {
     i
 }
 
+/// Returns the number of leading bytes in `s` that are JSON whitespace
+/// (` `, `\t`, `\r`, or `\n`).
+///
+/// Most calls in compact JSON pass strings whose first byte is non-whitespace,
+/// so a byte-by-byte loop is faster than an 8-byte SWAR setup cost. The
+/// compiler turns the match into a fast dispatch and unrolls the loop for
+/// any longer run.
+#[inline]
+pub(crate) fn skip_json_whitespace(s: &[u8]) -> usize {
+    let mut i = 0;
+    while i < s.len() && matches!(s[i], b' ' | b'\t' | b'\r' | b'\n') {
+        i += 1;
+    }
+    i
+}
+
 /// Returns the number of leading bytes in `s` that are ASCII digits (`'0'..='9'`).
 pub(crate) fn skip_ascii_digits(s: &[u8]) -> usize {
     let mut i = 0;
@@ -363,5 +379,59 @@ mod tests {
                 "non-digit '.' at position {pos}"
             );
         }
+    }
+
+    #[test]
+    fn ws_empty_and_short() {
+        assert_eq!(skip_json_whitespace(b""), 0);
+        assert_eq!(skip_json_whitespace(b" "), 1);
+        assert_eq!(skip_json_whitespace(b"\t"), 1);
+        assert_eq!(skip_json_whitespace(b"\r"), 1);
+        assert_eq!(skip_json_whitespace(b"\n"), 1);
+        assert_eq!(skip_json_whitespace(b"  \t \n "), 6);
+        assert_eq!(skip_json_whitespace(b"a"), 0);
+    }
+
+    #[test]
+    fn ws_full_chunk() {
+        assert_eq!(skip_json_whitespace(b"        "), 8);
+        assert_eq!(skip_json_whitespace(b"\t\n\r \t\n\r "), 8);
+        assert_eq!(skip_json_whitespace(b"        \t       "), 16);
+    }
+
+    #[test]
+    fn ws_stop_at_non_ws() {
+        assert_eq!(skip_json_whitespace(b"   abc"), 3);
+        assert_eq!(skip_json_whitespace(b"\n\n{"), 2);
+        // Non-whitespace at every chunk boundary position.
+        for pos in 0..16 {
+            let mut buf = [b' '; 16];
+            buf[pos] = b'a';
+            assert_eq!(
+                skip_json_whitespace(&buf),
+                pos,
+                "non-ws 'a' at position {pos}"
+            );
+        }
+    }
+
+    #[test]
+    fn ws_excludes_non_json_whitespace() {
+        // Vertical tab (0x0B), form feed (0x0C), and other low ASCII are NOT
+        // JSON whitespace.
+        assert_eq!(skip_json_whitespace(b"\x0B"), 0);
+        assert_eq!(skip_json_whitespace(b"\x0C"), 0);
+        assert_eq!(skip_json_whitespace(b"\x00"), 0);
+        // Non-breaking space (Unicode U+00A0, UTF-8 0xC2 0xA0) is not JSON ws.
+        assert_eq!(skip_json_whitespace(b"\xC2\xA0"), 0);
+    }
+
+    #[test]
+    fn ws_long_run() {
+        let buf = [b' '; 1024];
+        assert_eq!(skip_json_whitespace(&buf), 1024);
+        let mut buf2 = [b' '; 256];
+        buf2[200] = b'{';
+        assert_eq!(skip_json_whitespace(&buf2), 200);
     }
 }


### PR DESCRIPTION
## Summary

- `format`: emit contiguous non-ASCII runs in a single `write_str` (one slice
  instead of one char-by-char encode loop)
- `parse`: skip ASCII digit runs via SWAR (`skip_ascii_digits`) instead of
  `trim_start_matches([10 chars])`
- `parse`: skip JSON whitespace via a byte loop (`skip_json_whitespace`)
  instead of `trim_start_matches([4 chars])`

## Benchmark

20 `main` runs × 25 branch runs via `benchmark.yml`, CPU-matched best-of-N
(ubuntu-latest hits 3 generations of Azure VMs):

| case | EPYC 7763 | EPYC 9V74 | Xeon 8370C | Apple M1 |
|---|---|---|---|---|
| `format unicode_heavy_200ch` | 12.79x | 13.74x | 13.00x | 11.56x |
| `parse int_array_1000` | 1.62x | 1.72x | 1.63x | 1.57x |
| `parse float_array_1000` | 1.67x | 1.58x | 1.54x | 1.38x |
| `parse full_json_document_50users` | 1.10x | 1.06x | 1.11x | 1.02x |
| `parse jsonc_document_50users` | 1.05x | 1.06x | 1.14x | 1.11x |
| `parse many_short_keys_100` | 1.04x | 1.04x | 1.07x | 1.00x |

Other cases within ±5% (runner noise). No regressions.

