### PR TITLE
perf: shrink parsed-value entries from 32B to 16B

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,7 @@ mod parse_error;
 mod raw;
 mod swar;
 mod try_from_impls;
+mod values;
 
 use core::{fmt::Display, str::FromStr};
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3,7 +3,8 @@ use core::ops::Range;
 
 use crate::{
     JsonValueKind,
-    raw::{JsonParseError, JsonValueIndexEntry},
+    raw::JsonParseError,
+    values::{JsonValueIndexEntry, JsonValues},
 };
 
 pub trait Extensions {
@@ -32,26 +33,27 @@ pub struct JsonParser<'a, X> {
     original_text: &'a str,
     text: &'a str,
     kind: Option<JsonValueKind>,
-    values: Vec<JsonValueIndexEntry>,
+    values: JsonValues,
     comments: Vec<Range<usize>>,
     _extensions: core::marker::PhantomData<X>,
 }
 
 impl<'a, E: Extensions> JsonParser<'a, E> {
-    pub fn new(text: &'a str) -> Self {
-        Self {
+    pub fn new(text: &'a str) -> Result<Self, JsonParseError> {
+        if text.len() > u32::MAX as usize {
+            return Err(JsonParseError::InputTooLarge { size: text.len() });
+        }
+        Ok(Self {
             original_text: text,
             text,
             kind: None,
-            values: Vec::new(),
+            values: JsonValues::with_capacity(0),
             comments: Vec::new(),
             _extensions: core::marker::PhantomData,
-        }
+        })
     }
 
-    pub fn parse(
-        mut self,
-    ) -> Result<(Vec<JsonValueIndexEntry>, Vec<Range<usize>>), JsonParseError> {
+    pub fn parse(mut self) -> Result<(JsonValues, Vec<Range<usize>>), JsonParseError> {
         self.parse_value()?;
         self.check_trailing_char()?;
         Ok((self.values, self.comments))
@@ -297,7 +299,8 @@ impl<'a, E: Extensions> JsonParser<'a, E> {
                 Some(b'"') => {
                     let s = &s[1..];
                     self.push_entry(self.offset(s));
-                    self.values.last_mut().expect("infallible").escaped = escaped;
+                    let last = self.values.len() - 1;
+                    self.values.get_mut(last).set_escaped(escaped);
                     return Ok(());
                 }
                 Some(b'\\') => {
@@ -328,22 +331,26 @@ impl<'a, E: Extensions> JsonParser<'a, E> {
 
     fn push_entry(&mut self, len: usize) {
         let position = self.position();
-        let entry = JsonValueIndexEntry {
-            kind: self.kind.expect("infallible"),
-            escaped: false,
-            text: Range {
-                start: position,
-                end: position + len,
-            },
-            end_index: self.values.len() + 1,
-        };
-        self.values.push(entry);
+        // `JsonParser::new` rejects inputs larger than `u32::MAX`, so every
+        // position we compute here fits in a `u32`.
+        let start = position as u32;
+        let end = (position + len) as u32;
+        let end_index = (self.values.len() + 1) as u32;
+        self.values.push(JsonValueIndexEntry::new(
+            self.kind.expect("infallible"),
+            start,
+            end,
+            end_index,
+        ));
         self.text = &self.text[len..];
     }
 
     fn finalize_entry(&mut self, index: usize) {
-        self.values[index].text.end = self.position();
-        self.values[index].end_index = self.values.len();
+        let end = self.position() as u32;
+        let end_index = self.values.len() as u32;
+        let entry = self.values.get_mut(index);
+        entry.set_text_end(end);
+        entry.set_end_index(end_index);
     }
 
     fn position(&self) -> usize {

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -73,6 +73,15 @@ pub enum JsonParseError {
         /// Error reason that describes why the value is invalid.
         error: Box<dyn Send + Sync + core::error::Error>,
     },
+
+    /// The input document exceeds the size limit supported by this parser.
+    ///
+    /// Internal indices are stored as `u32`, so the parser rejects inputs
+    /// larger than `u32::MAX` bytes (~4 GiB) before attempting to parse them.
+    InputTooLarge {
+        /// Byte length of the rejected input.
+        size: usize,
+    },
 }
 
 impl JsonParseError {
@@ -95,6 +104,7 @@ impl JsonParseError {
             JsonParseError::UnexpectedTrailingChar { kind, .. } => Some(*kind),
             JsonParseError::UnexpectedValueChar { kind, .. } => *kind,
             JsonParseError::InvalidValue { kind, .. } => Some(*kind),
+            JsonParseError::InputTooLarge { .. } => None,
         }
     }
 
@@ -105,6 +115,7 @@ impl JsonParseError {
             | JsonParseError::UnexpectedTrailingChar { position, .. }
             | JsonParseError::UnexpectedValueChar { position, .. }
             | JsonParseError::InvalidValue { position, .. } => *position,
+            JsonParseError::InputTooLarge { .. } => 0,
         }
     }
 
@@ -235,6 +246,13 @@ impl core::fmt::Display for JsonParseError {
                 write!(
                     f,
                     "JSON {kind:?} at byte position {position} is invalid: {error}"
+                )
+            }
+            JsonParseError::InputTooLarge { size } => {
+                write!(
+                    f,
+                    "input of {size} bytes exceeds the parser's maximum size ({} bytes)",
+                    u32::MAX
                 )
             }
         }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -6,6 +6,7 @@ use core::{fmt::Display, hash::Hash, ops::Range};
 use crate::{
     DisplayJson, JsonArrayFormatter, JsonFormatter, JsonObjectFormatter, JsonValueKind,
     parse::{JsonParser, Jsonc, Plain},
+    values::JsonValues,
 };
 
 pub use crate::parse_error::JsonParseError;
@@ -14,7 +15,7 @@ pub use crate::parse_error::JsonParseError;
 #[derive(Debug, Clone)]
 pub struct RawJsonOwned {
     text: String,
-    values: Vec<JsonValueIndexEntry>,
+    values: JsonValues,
 }
 
 impl RawJsonOwned {
@@ -38,7 +39,7 @@ impl RawJsonOwned {
         T: Into<String>,
     {
         let text = text.into();
-        let (values, _) = JsonParser::<Plain>::new(&text).parse()?;
+        let (values, _) = JsonParser::<Plain>::new(&text)?.parse()?;
         Ok(Self { text, values })
     }
 
@@ -87,7 +88,7 @@ impl RawJsonOwned {
         T: Into<String>,
     {
         let text = text.into();
-        let (values, comments) = JsonParser::<Jsonc>::new(&text).parse()?;
+        let (values, comments) = JsonParser::<Jsonc>::new(&text)?.parse()?;
         Ok((Self { text, values }, comments))
     }
 
@@ -336,7 +337,7 @@ impl<'text, 'raw> TryFrom<RawJsonValue<'text, 'raw>> for RawJsonOwned {
 #[derive(Debug, Clone)]
 pub struct RawJson<'text> {
     text: &'text str,
-    values: Vec<JsonValueIndexEntry>,
+    values: JsonValues,
 }
 
 impl<'text> RawJson<'text> {
@@ -354,7 +355,7 @@ impl<'text> RawJson<'text> {
     /// # }
     /// ```
     pub fn parse(text: &'text str) -> Result<Self, JsonParseError> {
-        let (values, _) = JsonParser::<Plain>::new(text).parse()?;
+        let (values, _) = JsonParser::<Plain>::new(text)?.parse()?;
         Ok(Self { text, values })
     }
 
@@ -393,7 +394,7 @@ impl<'text> RawJson<'text> {
     /// # }
     /// ```
     pub fn parse_jsonc(text: &'text str) -> Result<(Self, Vec<Range<usize>>), JsonParseError> {
-        let (values, comments) = JsonParser::<Jsonc>::new(text).parse()?;
+        let (values, comments) = JsonParser::<Jsonc>::new(text)?.parse()?;
         Ok((Self { text, values }, comments))
     }
 
@@ -569,27 +570,19 @@ impl<'text, 'raw> TryFrom<RawJsonValue<'text, 'raw>> for RawJson<'text> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct JsonValueIndexEntry {
-    pub kind: JsonValueKind,
-    pub escaped: bool,
-    pub text: Range<usize>,
-    pub end_index: usize,
-}
-
 #[derive(Debug, Clone, Copy)]
 struct RawJsonRef<'text, 'raw> {
     text: &'text str,
-    values: &'raw [JsonValueIndexEntry],
+    values: &'raw JsonValues,
 }
 
 impl<'text, 'raw> RawJsonRef<'text, 'raw> {
     fn get_value_by_position(self, position: usize) -> Option<RawJsonValue<'text, 'raw>> {
         let mut value = self.value();
-        if !value.entry().text.contains(&position) {
+        if !value.text_range().contains(&position) {
             return None;
         }
-        while let Some(child) = Children::new(value).find(|c| c.entry().text.contains(&position)) {
+        while let Some(child) = Children::new(value).find(|c| c.text_range().contains(&position)) {
             value = child;
         }
         Some(value)
@@ -681,12 +674,12 @@ pub struct RawJsonValue<'text, 'raw> {
 impl<'text, 'raw> RawJsonValue<'text, 'raw> {
     /// Returns the kind of this JSON value.
     pub fn kind(self) -> JsonValueKind {
-        self.json.values[self.index].kind
+        self.json.values.get(self.index).kind()
     }
 
     /// Returns the byte position where this value begins in the JSON text (`self.json().text()`).
     pub fn position(self) -> usize {
-        self.json.values[self.index].text.start
+        self.json.values.get(self.index).text_start()
     }
 
     /// Returns the internal index of this value in the JSON structure.
@@ -769,8 +762,8 @@ impl<'text, 'raw> RawJsonValue<'text, 'raw> {
 
     /// Returns the raw JSON text of this value as-is.
     pub fn as_raw_str(self) -> &'text str {
-        let text = &self.json.values[self.index].text;
-        &self.json.text[text.start..text.end]
+        let range = self.json.values.get(self.index).text_range();
+        &self.json.text[range]
     }
 
     /// Converts this value to a borrowed [`RawJson`] containing just this value and its children.
@@ -805,26 +798,22 @@ impl<'text, 'raw> RawJsonValue<'text, 'raw> {
     /// ```
     pub fn extract(self) -> RawJson<'text> {
         let start_index = self.index;
-        let end_index = self.entry().end_index;
+        let root = self.json.values.get(start_index);
+        let end_index = root.end_index();
 
-        // Extract the text range that covers this value and all its children
-        let start_pos = self.entry().text.start;
-        let end_pos = self.entry().text.end;
+        let start_pos = root.text_start();
+        let end_pos = root.text_end();
         let value_text = &self.json.text[start_pos..end_pos];
 
-        // Extract all relevant value entries (this value and its children)
-        let relevant_entries = &self.json.values[start_index..end_index];
-
-        // Create new values vector with adjusted positions
-        let new_values = relevant_entries
-            .iter()
-            .map(|entry| JsonValueIndexEntry {
-                kind: entry.kind,
-                escaped: entry.escaped,
-                text: (entry.text.start - start_pos)..(entry.text.end - start_pos),
-                end_index: entry.end_index - start_index,
-            })
-            .collect();
+        let text_offset = start_pos as u32;
+        let index_offset = start_index as u32;
+        let new_values = JsonValues::from_iter(
+            self.json
+                .values
+                .slice(start_index..end_index)
+                .iter()
+                .map(|e| e.shifted(text_offset, index_offset)),
+        );
 
         RawJson {
             text: value_text,
@@ -952,7 +941,7 @@ impl<'text, 'raw> RawJsonValue<'text, 'raw> {
     /// ```
     pub fn as_string_str(self) -> Result<&'text str, JsonParseError> {
         self.expect([JsonValueKind::String]).and_then(|v| {
-            if v.entry().escaped {
+            if v.json.values.get(v.index).escaped() {
                 Err(v.invalid("string requires unescaping"))
             } else {
                 // Safe to unwrap: we know it's a valid JSON string with quotes
@@ -1195,7 +1184,7 @@ impl<'text, 'raw> RawJsonValue<'text, 'raw> {
         debug_assert!(self.kind().is_string());
 
         let content = &self.as_raw_str()[1..self.as_raw_str().len() - 1];
-        if !self.entry().escaped {
+        if !self.json.values.get(self.index).escaped() {
             return Cow::Borrowed(content);
         }
 
@@ -1256,8 +1245,8 @@ impl<'text, 'raw> RawJsonValue<'text, 'raw> {
             .find_map(|(k, v)| (k.unquote() == name).then_some(v)))
     }
 
-    fn entry(&self) -> &JsonValueIndexEntry {
-        &self.json.values[self.index]
+    fn text_range(&self) -> Range<usize> {
+        self.json.values.get(self.index).text_range()
     }
 }
 
@@ -1295,7 +1284,7 @@ struct Children<'text, 'raw> {
 
 impl<'text, 'raw> Children<'text, 'raw> {
     fn new(mut value: RawJsonValue<'text, 'raw>) -> Self {
-        let end_index = value.entry().end_index;
+        let end_index = value.json.values.get(value.index).end_index();
         value.index += 1;
         Self { value, end_index }
     }
@@ -1309,7 +1298,7 @@ impl<'text, 'raw> Iterator for Children<'text, 'raw> {
             return None;
         }
         let value = self.value;
-        self.value.index = value.entry().end_index;
+        self.value.index = value.json.values.get(value.index).end_index();
         Some(value)
     }
 }

--- a/src/values.rs
+++ b/src/values.rs
@@ -1,0 +1,151 @@
+//! Compact storage for parsed JSON value entries.
+//!
+//! Each entry holds a text range and structural link. Positions are stored as
+//! `u32` (capping single documents at `u32::MAX` bytes — the parser refuses
+//! larger inputs), and the kind + escaped flag share one byte, so an entry
+//! costs 16 bytes instead of the 32 that `usize` fields required. Halving the
+//! per-entry footprint doubles the number of entries that fit in a cache line
+//! during structural traversal.
+
+use alloc::vec::Vec;
+use core::ops::Range;
+
+use crate::JsonValueKind;
+
+const KIND_MASK: u8 = 0x7F;
+const ESCAPED_BIT: u8 = 0x80;
+
+/// One parsed JSON value slot. 16 bytes on all targets (asserted below).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct JsonValueIndexEntry {
+    // Text range in the source, `[text_start, text_end)`.
+    text_start: u32,
+    text_end: u32,
+    // For containers, one past the last descendant slot; for scalars, `index + 1`.
+    end_index: u32,
+    // Bit 7 = escaped flag; bits 0-6 = kind ordinal.
+    packed: u8,
+}
+
+const _: () = assert!(core::mem::size_of::<JsonValueIndexEntry>() == 16);
+
+impl JsonValueIndexEntry {
+    pub(crate) fn new(kind: JsonValueKind, start: u32, end: u32, end_index: u32) -> Self {
+        Self {
+            text_start: start,
+            text_end: end,
+            end_index,
+            packed: kind_to_byte(kind),
+        }
+    }
+
+    pub(crate) fn kind(&self) -> JsonValueKind {
+        byte_to_kind(self.packed & KIND_MASK)
+    }
+
+    pub(crate) fn escaped(&self) -> bool {
+        self.packed & ESCAPED_BIT != 0
+    }
+
+    pub(crate) fn text_start(&self) -> usize {
+        self.text_start as usize
+    }
+
+    pub(crate) fn text_end(&self) -> usize {
+        self.text_end as usize
+    }
+
+    pub(crate) fn text_range(&self) -> Range<usize> {
+        self.text_start()..self.text_end()
+    }
+
+    pub(crate) fn end_index(&self) -> usize {
+        self.end_index as usize
+    }
+
+    pub(crate) fn set_text_end(&mut self, end: u32) {
+        self.text_end = end;
+    }
+
+    pub(crate) fn set_end_index(&mut self, end_index: u32) {
+        self.end_index = end_index;
+    }
+
+    pub(crate) fn set_escaped(&mut self, escaped: bool) {
+        self.packed = (self.packed & KIND_MASK) | if escaped { ESCAPED_BIT } else { 0 };
+    }
+
+    /// Adjust text positions and end_index by the given offsets. Used by
+    /// [`RawJsonValue::extract`] when materialising a sub-tree.
+    pub(crate) fn shifted(&self, text_offset: u32, index_offset: u32) -> Self {
+        Self {
+            text_start: self.text_start - text_offset,
+            text_end: self.text_end - text_offset,
+            end_index: self.end_index - index_offset,
+            packed: self.packed,
+        }
+    }
+}
+
+/// Owning column of entries. Kept as a thin newtype so future refactors (say,
+/// splitting into SoA if profiling later warrants it) can happen behind this
+/// crate-internal API without touching call sites.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct JsonValues(Vec<JsonValueIndexEntry>);
+
+impl JsonValues {
+    pub(crate) fn with_capacity(cap: usize) -> Self {
+        Self(Vec::with_capacity(cap))
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub(crate) fn push(&mut self, entry: JsonValueIndexEntry) {
+        self.0.push(entry);
+    }
+
+    pub(crate) fn get(&self, i: usize) -> &JsonValueIndexEntry {
+        &self.0[i]
+    }
+
+    pub(crate) fn get_mut(&mut self, i: usize) -> &mut JsonValueIndexEntry {
+        &mut self.0[i]
+    }
+
+    pub(crate) fn slice(&self, range: Range<usize>) -> &[JsonValueIndexEntry] {
+        &self.0[range]
+    }
+
+    pub(crate) fn from_iter<I: IntoIterator<Item = JsonValueIndexEntry>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+#[inline(always)]
+fn kind_to_byte(kind: JsonValueKind) -> u8 {
+    match kind {
+        JsonValueKind::Null => 0,
+        JsonValueKind::Boolean => 1,
+        JsonValueKind::Integer => 2,
+        JsonValueKind::Float => 3,
+        JsonValueKind::String => 4,
+        JsonValueKind::Array => 5,
+        JsonValueKind::Object => 6,
+    }
+}
+
+#[inline(always)]
+fn byte_to_kind(byte: u8) -> JsonValueKind {
+    match byte {
+        0 => JsonValueKind::Null,
+        1 => JsonValueKind::Boolean,
+        2 => JsonValueKind::Integer,
+        3 => JsonValueKind::Float,
+        4 => JsonValueKind::String,
+        5 => JsonValueKind::Array,
+        6 => JsonValueKind::Object,
+        _ => unreachable!("packed byte was written by kind_to_byte"),
+    }
+}


### PR DESCRIPTION
## Summary

Experimental refactor to shrink `JsonValueIndexEntry` from **32B to 16B** (`const _: () = assert!(size_of::<...>() == 16);` guards the invariant), realising the "Indices Instead of Pointers" technique from <https://www.arshad.fyi/writings/engineering-high-performance-parsers>.

- Text positions and `end_index` stored as `u32`
- `kind` + `escaped` flag packed into a single byte (bit 7 = escaped, bits 0-6 = kind ordinal)
- Inputs larger than `u32::MAX` bytes are rejected up front via a new `JsonParseError::InputTooLarge { size }` variant
- Public API is unchanged (`position()` etc. still return `usize`)

## Notes from the exploration

- A true SoA layout (4 parallel `Vec`s) was also tried but **regressed string-only parsing by 38 – 57%**, because tiny inputs pay the `push` / `grow` / `drop` bookkeeping four times over. This PR sticks with AoS and only compacts the entry.
- So this doesn't adopt the article's SoA point conceptually — only its underlying goal (better cache-line utilisation) is captured, via AoS + `u32` packing.

## Benchmark results (parse, ns/op — lower is better)

**Ubuntu EPYC 7763 (same CPU on both refs, CI)**

| case | main | branch | delta |
|---|---:|---:|---:|
| long_ascii_64B | 47.9 | 48.7 | +1.7% |
| long_ascii_1024B | 171.8 | 173.1 | +0.8% |
| many_short_keys_100 | 3369 | 3039 | **−9.8%** |
| unicode_heavy_200ch | 98.5 | 99.4 | +0.9% |
| int_array_1000 | 13250 | 11361 | **−14.3%** |
| float_array_1000 | 19068 | 17731 | **−7.0%** |
| full_json_document_50users | 11851 | 11105 | **−6.3%** |
| jsonc_document_50users | 18307 | 17119 | **−6.5%** |

**Local Apple Silicon (bare-metal)**

| case | main | branch | delta |
|---|---:|---:|---:|
| long_ascii_1024B | 136.4 | 135.3 | −0.8% |
| many_short_keys_100 | 2633 | 2575 | −2.2% |
| int_array_1000 | 14163 | 13471 | **−4.9%** |
| float_array_1000 | 20384 | 19634 | **−3.7%** |
| jsonc_document_50users | 12258 | 11878 | **−3.1%** |

**macOS-latest (Apple M1 Virtual)** — 6 – 24% variance between two consecutive runs of identical code, so single-sample comparisons are unreliable here. Reference-only.

## Why this isn't merged

Entry-heavy cases show a 3 – 14% improvement, but the trade-off is that **input size becomes hard-capped at `u32::MAX` (~4 GiB)**. The gain doesn't justify tightening the input contract, so this is closed as a reference for the future — if we later decide the 4 GiB cap is acceptable, this branch is the starting point.